### PR TITLE
remove more cugraph-only details, other miscellaneous build/packaging changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,9 +9,6 @@ python:
 benchmarks:
   - 'benchmarks/**'
 
-datasets:
-  - 'datasets/**'
-
 ci:
    - 'ci/**'
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,11 +1,13 @@
 name: build
 
 on:
-  push:
-    branches:
-      - "branch-*"
-    tags:
-      - v[0-9][0-9].[0-9][0-9].[0-9][0-9]
+  # TODO: uncomment this condition when ready to start publishing
+  #       packages from this repo
+  # push:
+  #   branches:
+  #     - "branch-*"
+  #   tags:
+  #     - v[0-9][0-9].[0-9][0-9].[0-9][0-9]
   workflow_dispatch:
     inputs:
       branch:
@@ -26,34 +28,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docs-build:
-    if: github.ref_type == 'branch'
-    needs: python-build
-    secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@python-3.12
-    with:
-      arch: "amd64"
-      branch: ${{ inputs.branch }}
-      build_type: ${{ inputs.build_type || 'branch' }}
-      container_image: "rapidsai/ci-conda:cuda11.8.0-ubuntu22.04-py3.10"
-      date: ${{ inputs.date }}
-      node_type: "gpu-v100-latest-1"
-      run_script: "ci/build_docs.sh"
-      sha: ${{ inputs.sha }}
   wheel-build-nx-cugraph:
-    needs: wheel-publish-pylibcugraph
+    needs: wheel-publish-nx-cugraph
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@python-3.12
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.12
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel_nx-cugraph.sh
+      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
   wheel-publish-nx-cugraph:
     needs: wheel-build-nx-cugraph
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@python-3.12
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.12
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   conda-python-tests:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@python-3.12
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-tests.yaml@branch-24.12
     with:
       build_type: nightly
       branch: ${{ inputs.branch }}
@@ -24,7 +24,7 @@ jobs:
       sha: ${{ inputs.sha }}
   wheel-tests-nx-cugraph:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@python-3.12
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.12
     with:
       build_type: nightly
       branch: ${{ inputs.branch }}

--- a/.gitignore
+++ b/.gitignore
@@ -64,12 +64,6 @@ build/
 
 ## Datasets
 datasets/*
-!datasets/cyber.csv
-!datasets/get_test_data.sh
-!datasets/karate-data.csv
-!datasets/karate_undirected.csv
-!datasets/karate-disjoint.csv
-!datasets/netscience.csv
 
 # nx-cugraph side effects
 objects.inv
@@ -81,8 +75,6 @@ objects.inv
 
 ## Doxygen and Docs
 cpp/doxygen/html
-docs/cugraph/lib*
-docs/cugraph/api/*
 
 # Sphinx docs & build artifacts
 docs/nx-cugraph/source/api_docs/api/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,12 +38,12 @@ repos:
           - flake8-bugbear==24.8.19
           - flake8-simplify==0.21.0
   - repo: https://github.com/asottile/yesqa
-    rev: v1.3.0
+    rev: v1.5.0
     hooks:
       - id: yesqa
         additional_dependencies: *flake8_dependencies
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.19
+    rev: v0.22
     hooks:
       - id: validate-pyproject
         name: Validate pyproject.toml
@@ -57,12 +57,12 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
+    rev: v3.19.0
     hooks:
       - id: pyupgrade
         args: [--py310-plus]
   - repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black
   - repo: https://github.com/codespell-project/codespell

--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ VALIDARGS="
 HELP="$0 [<target> ...] [<flag> ...]
  where <target> is:
    clean                      - remove all existing build artifacts and configuration (start over)
-   uninstall                  - uninstall libcugraph and cugraph from a prior build/install (see also -n)
+   uninstall                  - uninstall nx-cugraph from a prior build/install (see also -n)
    nx-cugraph                 - build the nx-cugraph Python package
    docs                       - build the docs
    all                        - build everything
@@ -69,7 +69,7 @@ function buildDefault {
 
 function cleanPythonDir {
     pushd $1 > /dev/null
-    rm -rf dist dask-worker-space cugraph/raft *.egg-info
+    rm -rf dist dask-worker-space *.egg-info
     find . -type d -name __pycache__ -print | xargs rm -rf
     find . -type d -name build -print | xargs rm -rf
     find . -type d -name dist -print | xargs rm -rf

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -52,10 +52,9 @@ for FILE in dependencies.yaml conda/environments/*.yaml conda/recipes/**/meta.ya
     sed_runner "/-.* ${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0/g" "${FILE}"
   done
 done
-for FILE in python/**/pyproject.toml python/**/**/pyproject.toml; do
-  for DEP in "${DEPENDENCIES[@]}"; do
-    sed_runner "/\"${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*\"/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\"/g" "${FILE}"
-  done
+
+for DEP in "${DEPENDENCIES[@]}"; do
+  sed_runner "/\"${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*\"/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\"/g" ./pyproject.toml
 done
 
 # CI files
@@ -64,3 +63,8 @@ for FILE in .github/workflows/*.yaml; do
 done
 
 sed_runner "s/branch-[0-9][0-9].[0-9][0-9]/branch-${NEXT_SHORT_TAG}/" ./docs/nx-cugraph/source/nx_cugraph/nx_cugraph.md
+
+# issue templates
+for FILE in ./.github/ISSUE_TEMPLATE/*.yaml; do
+  sed_runner "s/example\: ${CURRENT_SHORT_TAG}/example: ${NEXT_SHORT_TAG}/" "${FILE}"
+done

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Copyright (c) 2018-2024, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Usage
+# bash update-version.sh <new_version>
+
+# Format is YY.MM.PP - no leading 'v' or trailing 'a'
+NEXT_FULL_TAG=$1
+
+# Get current version
+CURRENT_TAG=$(git tag --merged HEAD | grep -xE '^v.*' | sort --version-sort | tail -n 1 | tr -d 'v')
+CURRENT_MAJOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[1]}')
+CURRENT_MINOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[2]}')
+CURRENT_SHORT_TAG=${CURRENT_MAJOR}.${CURRENT_MINOR}
+
+# Get <major>.<minor> for next version
+NEXT_MAJOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[1]}')
+NEXT_MINOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[2]}')
+NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
+
+echo "Preparing release $CURRENT_TAG => $NEXT_FULL_TAG"
+
+# Inplace sed replace; workaround for Linux and Mac
+function sed_runner() {
+    sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
+}
+
+# Centralized version file update
+echo "${NEXT_FULL_TAG}" > ./VERSION
+
+# Need to distutils-normalize the original version
+NEXT_SHORT_TAG_PEP440=$(python -c "from packaging.version import Version; print(Version('${NEXT_SHORT_TAG}'))")
+
+DEPENDENCIES=(
+  cudf
+  cugraph
+  pylibcugraph
+)
+for FILE in dependencies.yaml conda/environments/*.yaml conda/recipes/**/meta.yaml; do
+  for DEP in "${DEPENDENCIES[@]}"; do
+    sed_runner "/-.* ${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0/g" "${FILE}"
+  done
+done
+for FILE in python/**/pyproject.toml python/**/**/pyproject.toml; do
+  for DEP in "${DEPENDENCIES[@]}"; do
+    sed_runner "/\"${DEP}\(-cu[[:digit:]]\{2\}\)\{0,1\}==/ s/==.*\"/==${NEXT_SHORT_TAG_PEP440}.*,>=0.0.0a0\"/g" "${FILE}"
+  done
+done
+
+# CI files
+for FILE in .github/workflows/*.yaml; do
+  sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
+done
+
+sed_runner "s/branch-[0-9][0-9].[0-9][0-9]/branch-${NEXT_SHORT_TAG}/" ./docs/nx-cugraph/source/nx_cugraph/nx_cugraph.md

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -155,9 +155,6 @@ dependencies:
         packages:
           - ipython
           - notebook>=0.5.0
-      - output_types: [conda]
-        packages:
-          - wget
   test_python_common:
     common:
       - output_types: [conda, pyproject]

--- a/print_env.sh
+++ b/print_env.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Copyright (c) 2019-2024, NVIDIA CORPORATION.
 # Reports relevant environment information useful for diagnosing and
-# debugging cuGraph issues.
+# debugging nx-cugraph issues.
 # Usage:
 # "./print_env.sh" - prints to stdout
 # "./print_env.sh > env.txt" - prints to file "env.txt"


### PR DESCRIPTION
Proposes another batch of changes to get this repo ready to become the primary home of `nx-cugraph` development.

* removes some unnecessary configuration leftover from the `cugraph` repo
* updates CI configs
* adds a `ci/update-release.sh` script (which RAPIDS ops will use when cutting new releases)
* updates all pre-commit hooks to their latest versions

## Notes for Reviewers

I'll leave more comments inline.