### PR TITLE
Add `nx-cugraph` Package Publishing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,13 +1,11 @@
 name: build
 
 on:
-  # TODO: uncomment this condition when ready to start publishing
-  #       packages from this repo
-  # push:
-  #   branches:
-  #     - "branch-*"
-  #   tags:
-  #     - v[0-9][0-9].[0-9][0-9].[0-9][0-9]
+  push:
+    branches:
+      - "branch-*"
+    tags:
+      - v[0-9][0-9].[0-9][0-9].[0-9][0-9]
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,8 +26,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  conda-python-build:
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.12
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
+  upload-conda:
+    needs: conda-python-build
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-24.12
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
   wheel-build-nx-cugraph:
-    needs: wheel-publish-nx-cugraph
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.12
     with:
@@ -36,7 +52,7 @@ jobs:
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}
       script: ci/build_wheel_nx-cugraph.sh
-      # This selects "ARCH=amd64 + the latest supported Python + CUDA".
+      # This selects "ARCH=amd64 + the latest supported Python, 1 job per major CUDA version".
       matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
   wheel-publish-nx-cugraph:
     needs: wheel-build-nx-cugraph


### PR DESCRIPTION
Closes https://github.com/rapidsai/graph_dl/issues/647

Updates `build.yaml` to enable building & publishing packages from this repo.

Scripts are copied from `build.yaml` from branch-24.12 in https://github.com/rapidsai/cugraph.