### PR TITLE
Update automatic "Python" labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,7 +3,8 @@
 # Labels culled from https://github.com/rapidsai/nx-cugraph/labels
 
 python:
-  - 'python/**'
+  - 'nx_cugraph/**'
+  - '_nx_cugraph/**'
   - 'notebooks/**'
 
 benchmarks:


### PR DESCRIPTION
Triggered by changes to `nx_cugraph/` and `_nx_cugraph`.

Is this label still useful to us or to ops?