### PR TITLE
remove versioning workaround for nightlies

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -9,10 +9,7 @@ source rapids-date-string
 
 rapids-print-env
 
-# TODO: revert this once we start publishing nightly packages from the
-#       'nx-cugraph' repo and stop publishing them from the 'cugraph' repo
-# rapids-generate-version > ./VERSION
-echo "24.12.00a1000" > ./VERSION
+rapids-generate-version > ./VERSION
 
 rapids-logger "Begin py build"
 

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -32,11 +32,9 @@ mkdir -p "${RAPIDS_TESTS_DIR}" "${RAPIDS_COVERAGE_DIR}"
 
 rapids-print-env
 
-  # TODO: remove the '>=24.12.00a1000' once we start publishing nightly packages
-  #       from the 'nx-cugraph' repo and stop publishing them from the 'cugraph' repo
 rapids-mamba-retry install \
   --channel "${PYTHON_CHANNEL}" \
-  "nx-cugraph=${RAPIDS_VERSION}.*,>=24.12.00a1000"
+  "nx-cugraph=${RAPIDS_VERSION}.*"
 
 rapids-logger "Check GPU usage"
 nvidia-smi

--- a/nx_cugraph/algorithms/core.py
+++ b/nx_cugraph/algorithms/core.py
@@ -46,6 +46,7 @@ def core_number(G):
         degree_type="bidirectional",
         do_expensive_check=False,
     )
+    core_numbers = core_numbers // 2  # Added this in 24.12 (behavior changed)
     return G._nodearrays_to_dict(node_ids, core_numbers)
 
 


### PR DESCRIPTION
Within this release, `nx-cugraph` moved from https://github.com/rapidsai/cugraph to this repo.

To avoid conflicts between nightlies produced from the different sources, CI scripts here were hard-coding the version for CI artifacts to `24.12.00a1000`. That should be removed now that this is the only repo packages are being published from (should have been removed in #16, sorry for missing it).