### PR TITLE
Add `can_run` that checks `create_using` argument

### DIFF
--- a/nx_cugraph/algorithms/bipartite/generators.py
+++ b/nx_cugraph/algorithms/bipartite/generators.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/nx_cugraph/algorithms/bipartite/generators.py
+++ b/nx_cugraph/algorithms/bipartite/generators.py
@@ -25,7 +25,7 @@ __all__ = [
 ]
 
 
-@networkx_algorithm(nodes_or_number=[0, 1], version_added="23.12")
+@networkx_algorithm(nodes_or_number=[0, 1], version_added="23.12", create_using_arg=2)
 def complete_bipartite_graph(n1, n2, create_using=None):
     graph_class, inplace = _create_using_class(create_using)
     if graph_class.is_directed():

--- a/nx_cugraph/convert.py
+++ b/nx_cugraph/convert.py
@@ -780,7 +780,7 @@ def _to_undirected_graph(
     raise TypeError
 
 
-@networkx_algorithm(version_added="24.08", fallback=True)
+@networkx_algorithm(version_added="24.08", fallback=True, create_using_arg=1)
 def from_dict_of_lists(d, create_using=None):
     from .generators._utils import _create_using_class
 

--- a/nx_cugraph/convert.py
+++ b/nx_cugraph/convert.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/nx_cugraph/convert_matrix.py
+++ b/nx_cugraph/convert_matrix.py
@@ -26,7 +26,9 @@ __all__ = [
 
 
 # Value columns with string dtype is not supported
-@networkx_algorithm(is_incomplete=True, version_added="23.12", fallback=True)
+@networkx_algorithm(
+    is_incomplete=True, version_added="23.12", fallback=True, create_using_arg=4
+)
 def from_pandas_edgelist(
     df,
     source="source",
@@ -163,7 +165,7 @@ def from_pandas_edgelist(
     return G
 
 
-@networkx_algorithm(version_added="23.12", fallback=True)
+@networkx_algorithm(version_added="23.12", fallback=True, create_using_arg=2)
 def from_scipy_sparse_array(
     A, parallel_edges=False, create_using=None, edge_attribute="weight"
 ):

--- a/nx_cugraph/convert_matrix.py
+++ b/nx_cugraph/convert_matrix.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/nx_cugraph/generators/classic.py
+++ b/nx_cugraph/generators/classic.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/nx_cugraph/generators/classic.py
+++ b/nx_cugraph/generators/classic.py
@@ -52,7 +52,7 @@ __all__ = [
 concat = itertools.chain.from_iterable
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=2)
 def barbell_graph(m1, m2, create_using=None):
     # Like two complete graphs and a path_graph
     m1 = _ensure_nonnegative_int(m1)
@@ -82,12 +82,12 @@ def barbell_graph(m1, m2, create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=1)
 def circular_ladder_graph(n, create_using=None):
     return _ladder_graph(n, create_using, is_circular=True)
 
 
-@networkx_algorithm(nodes_or_number=0, version_added="23.12")
+@networkx_algorithm(nodes_or_number=0, version_added="23.12", create_using_arg=1)
 def complete_graph(n, create_using=None):
     n, nodes = _number_and_nodes(n)
     if n < 3:
@@ -147,7 +147,7 @@ def complete_multipartite_graph(*subset_sizes):
     )
 
 
-@networkx_algorithm(nodes_or_number=0, version_added="23.12")
+@networkx_algorithm(nodes_or_number=0, version_added="23.12", create_using_arg=1)
 def cycle_graph(n, create_using=None):
     n, nodes = _number_and_nodes(n)
     graph_class, inplace = _create_using_class(create_using)
@@ -177,7 +177,7 @@ def cycle_graph(n, create_using=None):
     return G
 
 
-@networkx_algorithm(nodes_or_number=0, version_added="23.12")
+@networkx_algorithm(nodes_or_number=0, version_added="23.12", create_using_arg=1)
 def empty_graph(n=0, create_using=None, default=nx.Graph):
     n, nodes = _number_and_nodes(n)
     graph_class, inplace = _create_using_class(create_using, default=default)
@@ -239,12 +239,12 @@ def _ladder_graph(n, create_using, *, is_circular=False):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=1)
 def ladder_graph(n, create_using=None):
     return _ladder_graph(n, create_using)
 
 
-@networkx_algorithm(nodes_or_number=[0, 1], version_added="23.12")
+@networkx_algorithm(nodes_or_number=[0, 1], version_added="23.12", create_using_arg=2)
 def lollipop_graph(m, n, create_using=None):
     # Like complete_graph then path_graph
     orig_m, unused_nodes_m = m
@@ -279,12 +279,12 @@ def lollipop_graph(m, n, create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def null_graph(create_using=None):
     return _common_small_graph(0, None, create_using)
 
 
-@networkx_algorithm(nodes_or_number=0, version_added="23.12")
+@networkx_algorithm(nodes_or_number=0, version_added="23.12", create_using_arg=1)
 def path_graph(n, create_using=None):
     n, nodes = _number_and_nodes(n)
     graph_class, inplace = _create_using_class(create_using)
@@ -304,7 +304,7 @@ def path_graph(n, create_using=None):
     return G
 
 
-@networkx_algorithm(nodes_or_number=0, version_added="23.12")
+@networkx_algorithm(nodes_or_number=0, version_added="23.12", create_using_arg=1)
 def star_graph(n, create_using=None):
     orig_n, orig_nodes = n
     n, nodes = _number_and_nodes(n)
@@ -328,7 +328,7 @@ def star_graph(n, create_using=None):
     return G
 
 
-@networkx_algorithm(nodes_or_number=[0, 1], version_added="23.12")
+@networkx_algorithm(nodes_or_number=[0, 1], version_added="23.12", create_using_arg=2)
 def tadpole_graph(m, n, create_using=None):
     orig_m, unused_nodes_m = m
     orig_n, unused_nodes_n = n
@@ -366,7 +366,7 @@ def tadpole_graph(m, n, create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def trivial_graph(create_using=None):
     return _common_small_graph(1, None, create_using)
 
@@ -380,7 +380,7 @@ def turan_graph(n, r):
     return complete_multipartite_graph(*partitions)
 
 
-@networkx_algorithm(nodes_or_number=0, version_added="23.12")
+@networkx_algorithm(nodes_or_number=0, version_added="23.12", create_using_arg=1)
 def wheel_graph(n, create_using=None):
     n, nodes = _number_and_nodes(n)
     graph_class, inplace = _create_using_class(create_using)

--- a/nx_cugraph/generators/small.py
+++ b/nx_cugraph/generators/small.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/nx_cugraph/generators/small.py
+++ b/nx_cugraph/generators/small.py
@@ -44,7 +44,7 @@ __all__ = [
 ]
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def bull_graph(create_using=None):
     graph_class, inplace = _create_using_class(create_using)
     if graph_class.is_directed():
@@ -57,7 +57,7 @@ def bull_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def chvatal_graph(create_using=None):
     graph_class, inplace = _create_using_class(create_using)
     if graph_class.is_directed():
@@ -86,7 +86,7 @@ def chvatal_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def cubical_graph(create_using=None):
     graph_class, inplace = _create_using_class(create_using)
     if graph_class.is_directed():
@@ -106,7 +106,7 @@ def cubical_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def desargues_graph(create_using=None):
     # This can also be defined w.r.t. LCF_graph
     graph_class, inplace = _create_using_class(create_using)
@@ -147,7 +147,7 @@ def desargues_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def diamond_graph(create_using=None):
     graph_class, inplace = _create_using_class(create_using)
     if graph_class.is_directed():
@@ -160,7 +160,7 @@ def diamond_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def dodecahedral_graph(create_using=None):
     # This can also be defined w.r.t. LCF_graph
     graph_class, inplace = _create_using_class(create_using)
@@ -201,7 +201,7 @@ def dodecahedral_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def frucht_graph(create_using=None):
     graph_class, inplace = _create_using_class(create_using)
     if graph_class.is_directed():
@@ -236,7 +236,7 @@ def frucht_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def heawood_graph(create_using=None):
     # This can also be defined w.r.t. LCF_graph
     graph_class, inplace = _create_using_class(create_using)
@@ -275,7 +275,7 @@ def heawood_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def house_graph(create_using=None):
     graph_class, inplace = _create_using_class(create_using)
     if graph_class.is_directed():
@@ -288,7 +288,7 @@ def house_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def house_x_graph(create_using=None):
     graph_class, inplace = _create_using_class(create_using)
     if graph_class.is_directed():
@@ -307,7 +307,7 @@ def house_x_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def icosahedral_graph(create_using=None):
     graph_class, inplace = _create_using_class(create_using)
     if graph_class.is_directed():
@@ -338,7 +338,7 @@ def icosahedral_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def krackhardt_kite_graph(create_using=None):
     graph_class, inplace = _create_using_class(create_using)
     if graph_class.is_directed():
@@ -367,7 +367,7 @@ def krackhardt_kite_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def moebius_kantor_graph(create_using=None):
     # This can also be defined w.r.t. LCF_graph
     graph_class, inplace = _create_using_class(create_using)
@@ -408,7 +408,7 @@ def moebius_kantor_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def octahedral_graph(create_using=None):
     graph_class, inplace = _create_using_class(create_using)
     if graph_class.is_directed():
@@ -460,7 +460,7 @@ def pappus_graph():
     )
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def petersen_graph(create_using=None):
     graph_class, inplace = _create_using_class(create_using)
     if graph_class.is_directed():
@@ -487,7 +487,7 @@ def petersen_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def sedgewick_maze_graph(create_using=None):
     graph_class, inplace = _create_using_class(create_using)
     if graph_class.is_directed():
@@ -508,7 +508,7 @@ def sedgewick_maze_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def tetrahedral_graph(create_using=None):
     # This can also be defined w.r.t. complete_graph
     graph_class, inplace = _create_using_class(create_using)
@@ -525,7 +525,7 @@ def tetrahedral_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def truncated_cube_graph(create_using=None):
     graph_class, inplace = _create_using_class(create_using)
     if graph_class.is_directed():
@@ -556,7 +556,7 @@ def truncated_cube_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def truncated_tetrahedron_graph(create_using=None):
     graph_class, inplace = _create_using_class(create_using)
     if graph_class.is_directed():
@@ -591,7 +591,7 @@ def truncated_tetrahedron_graph(create_using=None):
     return G
 
 
-@networkx_algorithm(version_added="23.12")
+@networkx_algorithm(version_added="23.12", create_using_arg=0)
 def tutte_graph(create_using=None):
     graph_class, inplace = _create_using_class(create_using)
     if graph_class.is_directed():

--- a/nx_cugraph/tests/test_generators.py
+++ b/nx_cugraph/tests/test_generators.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/nx_cugraph/tests/test_generators.py
+++ b/nx_cugraph/tests/test_generators.py
@@ -47,10 +47,8 @@ def compare(name, create_using, *args, is_vanilla=False):
             Gcg = func(*args, create_using=create_using, backend="cugraph")
     except ZeroDivisionError:
         raise
-    except NotImplementedError as exc:
-        if name in {"complete_multipartite_graph"}:  # nx.__version__[:3] <= "3.2"
-            return
-        exc2 = exc
+    except NotImplementedError:
+        return
     except Exception as exc:
         if exc1 is None:  # pragma: no cover (debug)
             raise

--- a/nx_cugraph/tests/test_match_api.py
+++ b/nx_cugraph/tests/test_match_api.py
@@ -52,7 +52,10 @@ def test_match_signature_and_names():
                     if name not in extra_params
                 ]
             ), name
-        if func.can_run is not nxcg.utils.decorators._default_can_run:
+        if (
+            func.can_run is not nxcg.utils.decorators._default_can_run
+            and func.create_using_arg is None
+        ):
             assert func_sig == inspect.signature(func.can_run), name
         if func.should_run is not nxcg.utils.decorators._default_should_run:
             assert func_sig == inspect.signature(func.should_run), name
@@ -102,3 +105,12 @@ def test_match_signature_and_names():
                 raise AssertionError(
                     f"{mod_name} exists in {nx_path}, but not in {nxcg_path}"
                 )
+
+        # Check `create_using`
+        if "create_using" in func_sig.parameters:
+            assert func.create_using_arg is not None, name
+            params = list(func_sig.parameters)
+            assert params[func.create_using_arg] == "create_using", name
+            assert func.can_run is not nxcg.utils.decorators._default_can_run, name
+        else:
+            assert func.create_using_arg is None, name

--- a/nx_cugraph/tests/test_match_api.py
+++ b/nx_cugraph/tests/test_match_api.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/nx_cugraph/utils/decorators.py
+++ b/nx_cugraph/utils/decorators.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
This should help give better log messages when `create_using` is an instance of a networkx graph, since we can't update an nx graph inplace.