### PR TITLE
Example using nx dispatch hooks (WIP) to print timing

### DIFF
--- a/_nx_cugraph/__init__.py
+++ b/_nx_cugraph/__init__.py
@@ -31,6 +31,19 @@ from _nx_cugraph._version import __version__
 # always be in <major>.<minor>.<build> format.
 (_version_major, _version_minor) = __version__.split(".")[:2]
 
+
+def dispatch_hook_impl(hook_name, hook_token, **kwargs):
+    import time
+
+    if hook_name == "on_call_with_backend_begin":
+        hook_token["cugraph"]["t0"] = time.time()
+    elif hook_name == "on_call_with_backend_end":
+        t = time.time() - hook_token["cugraph"]["t0"]
+        backend_name = kwargs["backend_name"]
+        dispatch_name = hook_token.dispatchable.name
+        print(f"{backend_name!r} backend ran {dispatch_name} in {t:.3g} seconds")
+
+
 # Entries between BEGIN and END are automatically generated
 _info = {
     "backend_name": "cugraph",
@@ -38,6 +51,7 @@ _info = {
     "package": "nx_cugraph",
     "url": "https://rapids.ai/nx-cugraph",
     "short_summary": "GPU-accelerated backend.",
+    "dispatch_hook_impl": dispatch_hook_impl,
     # "description": "TODO",
     "functions": {
         # BEGIN: functions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,7 @@ ignore = [
 "__init__.py" = ["F401"]  # Allow unused imports (w/o defining `__all__`)
 # Allow assert, print, RNG, and no docstring
 "nx_cugraph/**/tests/*py" = ["S101", "S311", "T201", "D103", "D100"]
-"_nx_cugraph/__init__.py" = ["E501"]
+"_nx_cugraph/__init__.py" = ["E501", "T201"]
 "nx_cugraph/__init__.py" = ["E402"]  # Allow module level import not at top of file
 "nx_cugraph/algorithms/**/*py" = ["D205", "D401"]  # Allow flexible docstrings for algorithms
 "nx_cugraph/generators/**/*py" = ["D205", "D401"]  # Allow flexible docstrings for generators


### PR DESCRIPTION
Companion to https://github.com/networkx/networkx/pull/7765, which adds runtime dispatch hooks to networkx.

Example output:
```python
>>> pr = nx.pagerank(nx.complete_graph(1000))
'networkx' backend ran empty_graph in 0.00101 seconds
'networkx' backend ran complete_graph in 0.295 seconds
'networkx' backend ran to_scipy_sparse_array in 0.591 seconds
'networkx' backend ran pagerank in 0.6 seconds

>>> pr = nx.pagerank(nx.complete_graph(1000), backend="cugraph")
'networkx' backend ran empty_graph in 0.000839 seconds
'networkx' backend ran complete_graph in 0.296 seconds
'cugraph' backend ran pagerank in 0.0625 seconds

>>> pr = nx.pagerank(nx.complete_graph(1000, backend="cugraph"))
'cugraph' backend ran complete_graph in 0.00999 seconds
'cugraph' backend ran pagerank in 0.0264 seconds
```
This is super-basic to begin with. Let's try to find somebody who would want to create (and maintain) a fancier profiling backend.