### PR TITLE
Adds support for `jaccard_coefficient`

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Below is the list of algorithms that are currently supported in nx-cugraph.
  │   └─ <a href="https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.link_analysis.hits_alg.hits.html#networkx.algorithms.link_analysis.hits_alg.hits">hits</a>
  └─ <a href="https://networkx.org/documentation/stable/reference/algorithms/link_analysis.html#module-networkx.algorithms.link_analysis.pagerank_alg">pagerank_alg</a>
      └─ <a href="https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.link_analysis.pagerank_alg.pagerank.html#networkx.algorithms.link_analysis.pagerank_alg.pagerank">pagerank</a>
+<a href="https://networkx.org/documentation/stable/reference/algorithms/link_prediction.html#module-networkx.algorithms.link_prediction">link_prediction</a>
+ └─ <a href="https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.link_prediction.jaccard_coefficient.html#networkx.algorithms.link_prediction.jaccard_coefficient">jaccard_coefficient</a>
 <a href="https://networkx.org/documentation/stable/reference/algorithms/operators.html">operators</a>
  └─ <a href="https://networkx.org/documentation/stable/reference/algorithms/operators.html#module-networkx.algorithms.operators.unary">unary</a>
      ├─ <a href="https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.operators.unary.complement.html#networkx.algorithms.operators.unary.complement">complement</a>

--- a/_nx_cugraph/__init__.py
+++ b/_nx_cugraph/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -110,6 +110,7 @@ _info = {
         "is_tree",
         "is_weakly_connected",
         "isolates",
+        "jaccard_coefficient",
         "k_truss",
         "karate_club_graph",
         "katz_centrality",
@@ -182,6 +183,32 @@ _info = {
         "eigenvector_centrality": "`nstart` parameter is not used, but it is checked for validity.",
         "from_pandas_edgelist": "cudf.DataFrame inputs also supported; value columns with str is unsuppported.",
         "generic_bfs_edges": "`neighbors` parameter is not yet supported.",
+        "jaccard_coefficient": (
+            "Parameters\n"
+            "----------\n"
+            "G : graph\n"
+            "    A NetworkX or nx-cugraph undirected graph.\n"
+            "\n"
+            "ebunch : iterable of node pairs, optional (default = None)\n"
+            "    Jaccard coefficient will be computed for each pair of nodes\n"
+            "    given in the iterable. The pairs must be given as 2-tuples\n"
+            "    (u, v) where u and v are nodes in the graph. If ebunch is None\n"
+            "    then all nonexistent edges in the graph will be used.\n"
+            "\n"
+            "Returns\n"
+            "-------\n"
+            "piter : iterator\n"
+            "    An iterator of 3-tuples in the form (u, v, p) where (u, v) is a\n"
+            "    pair of nodes and p is their Jaccard coefficient.\n"
+            "\n"
+            "Raises\n"
+            "------\n"
+            "NetworkXNotImplemented\n"
+            "    If `G` is a `DiGraph`, a `Multigraph` or a `MultiDiGraph`.\n"
+            "\n"
+            "NodeNotFound\n"
+            "    If `ebunch` has a node that is not in `G`."
+        ),
         "katz_centrality": "`nstart` isn't used (but is checked), and `normalized=False` is not supported.",
         "louvain_communities": "`seed` parameter is currently ignored, and self-loops are not yet supported.",
         "pagerank": "`dangling` parameter is not supported, but it is checked for validity.",

--- a/_nx_cugraph/__init__.py
+++ b/_nx_cugraph/__init__.py
@@ -183,32 +183,6 @@ _info = {
         "eigenvector_centrality": "`nstart` parameter is not used, but it is checked for validity.",
         "from_pandas_edgelist": "cudf.DataFrame inputs also supported; value columns with str is unsuppported.",
         "generic_bfs_edges": "`neighbors` parameter is not yet supported.",
-        "jaccard_coefficient": (
-            "Parameters\n"
-            "----------\n"
-            "G : graph\n"
-            "    A NetworkX or nx-cugraph undirected graph.\n"
-            "\n"
-            "ebunch : iterable of node pairs, optional (default = None)\n"
-            "    Jaccard coefficient will be computed for each pair of nodes\n"
-            "    given in the iterable. The pairs must be given as 2-tuples\n"
-            "    (u, v) where u and v are nodes in the graph. If ebunch is None\n"
-            "    then all nonexistent edges in the graph will be used.\n"
-            "\n"
-            "Returns\n"
-            "-------\n"
-            "piter : iterator\n"
-            "    An iterator of 3-tuples in the form (u, v, p) where (u, v) is a\n"
-            "    pair of nodes and p is their Jaccard coefficient.\n"
-            "\n"
-            "Raises\n"
-            "------\n"
-            "NetworkXNotImplemented\n"
-            "    If `G` is a `DiGraph`, a `Multigraph` or a `MultiDiGraph`.\n"
-            "\n"
-            "NodeNotFound\n"
-            "    If `ebunch` has a node that is not in `G`."
-        ),
         "katz_centrality": "`nstart` isn't used (but is checked), and `normalized=False` is not supported.",
         "louvain_communities": "`seed` parameter is currently ignored, and self-loops are not yet supported.",
         "pagerank": "`dangling` parameter is not supported, but it is checked for validity.",

--- a/benchmarks/pytest-based/bench_algos.py
+++ b/benchmarks/pytest-based/bench_algos.py
@@ -197,7 +197,11 @@ def get_graph_obj_for_benchmark(graph_obj, backend_wrapper):
     """
     G = graph_obj
     if backend_wrapper.backend_name == "cugraph-preconverted":
-        G = nxcg.from_networkx(G, preserve_all_attrs=True)
+        G = nxcg.from_networkx(
+            G,
+            preserve_all_attrs=True,
+            use_compat_graph=True,
+        )
     return G
 
 
@@ -896,6 +900,35 @@ def bench_bipartite_BC_n1000_m3000_k100000(benchmark, backend_wrapper):
         warmup_rounds=warmup_rounds,
     )
     assert type(result) is dict
+
+
+def bench_jaccard(benchmark, graph_obj, backend_wrapper):
+    G = get_graph_obj_for_benchmark(graph_obj, backend_wrapper)
+
+    # ebunch is a list of node pairs to limit the jaccard run.
+    nodes = list(G.nodes)
+    start = nodes[0]
+    ebunch = [(start, n) for n in nodes[1:]]
+    start = nodes[1]
+    ebunch += [(start, n) for n in nodes[2:]]
+    start = nodes[2]
+    ebunch += [(start, n) for n in nodes[3:]]
+
+    # DiGraphs are not supported
+    if G.is_directed():
+        G = G.to_undirected()
+
+    result = benchmark.pedantic(
+        target=backend_wrapper(nx.jaccard_coefficient, force_unlazy_eval=True),
+        args=(G,),
+        kwargs=dict(
+            ebunch=ebunch,
+        ),
+        rounds=rounds,
+        iterations=iterations,
+        warmup_rounds=warmup_rounds,
+    )
+    assert type(result) is list
 
 
 @pytest.mark.skip(reason="benchmark not implemented")

--- a/nx_cugraph/algorithms/__init__.py
+++ b/nx_cugraph/algorithms/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -17,6 +17,7 @@ from . import (
     community,
     components,
     link_analysis,
+    link_prediction,
     operators,
     shortest_paths,
     traversal,
@@ -30,6 +31,7 @@ from .core import *
 from .dag import *
 from .isolate import *
 from .link_analysis import *
+from .link_prediction import *
 from .operators import *
 from .reciprocity import *
 from .shortest_paths import *

--- a/nx_cugraph/algorithms/link_prediction.py
+++ b/nx_cugraph/algorithms/link_prediction.py
@@ -49,19 +49,7 @@ def jaccard_coefficient(G, ebunch=None):
             # for invalid node IDs in ebunch.
             u_indices = G._list_to_nodearray(u)
             v_indices = G._list_to_nodearray(v)
-        except KeyError as n:
-            raise nx.NodeNotFound(f"Node {n} not in G.")
-
-        # If G was not renumbered, then the ebunch nodes must be explicitly
-        # checked. If not done, plc.jaccard_coefficients() will accept node IDs
-        # not in the graph and return a coefficient of 0 for them, which is not
-        # compatible with NX.
-        if (not hasattr(G, "key_to_id") or G.key_to_id is None) and (
-            (n := u_indices.max()) >= G._N
-            or (n := v_indices.max()) >= G._N
-            or (n := u_indices.min()) < 0
-            or (n := v_indices.min()) < 0
-        ):
+        except (KeyError, ValueError) as n:
             raise nx.NodeNotFound(f"Node {n} not in G.")
 
     (u, v, p) = plc.jaccard_coefficients(

--- a/nx_cugraph/algorithms/link_prediction.py
+++ b/nx_cugraph/algorithms/link_prediction.py
@@ -47,7 +47,7 @@ def jaccard_coefficient(G, ebunch=None):
         raise nx.NodeNotFound(f"Node {n} not in G.")
     else:
         # If G was not renumbered, then the ebunch nodes must be explicitly
-        # checked (note: ebunch can be very large).  plc.jaccard_coefficient()
+        # checked (note: ebunch can be very large).  plc.jaccard_coefficients()
         # will accept node IDs that are not in the graph and return a
         # coefficient of 0 for them.
         #

--- a/nx_cugraph/algorithms/link_prediction.py
+++ b/nx_cugraph/algorithms/link_prediction.py
@@ -15,7 +15,7 @@ import networkx as nx
 import pylibcugraph as plc
 
 from nx_cugraph.convert import _to_undirected_graph
-from nx_cugraph.utils import networkx_algorithm, not_implemented_for
+from nx_cugraph.utils import index_dtype, networkx_algorithm, not_implemented_for
 
 __all__ = [
     "jaccard_coefficient",
@@ -26,61 +26,49 @@ __all__ = [
 @not_implemented_for("multigraph")
 @networkx_algorithm(version_added="25.02", _plc="jaccard_coefficients")
 def jaccard_coefficient(G, ebunch=None):
-    if ebunch is None:
-        # FIXME: is there a more efficient way to do this (on GPU or
-        # otherwise)?
-        ebunch = list(nx.non_edges(G))
-        if not ebunch:
-            return iter([])
-
     G = _to_undirected_graph(G)
 
-    # FIXME: this zip() call appears to be the performance bottleneck for this
-    # function. Is there a better way?
-    (u, v) = zip(*ebunch)
+    # If ebunch is not specified, create pairs representing all non-edges.
+    # This can be an extremely large set and is not realistic for large graphs,
+    # but this is required for NX compatibility.
+    if ebunch is None:
+        A = cp.tri(G._N, G._N, dtype=bool)
+        A[G.src_indices, G.dst_indices] = True
+        u_indices, v_indices = cp.nonzero(~A)
+        if u_indices.size == 0:
+            return iter([])
+        u_indices = u_indices.astype(index_dtype)
+        v_indices = v_indices.astype(index_dtype)
 
-    try:
-        # Convert the ebunch lists to cupy arrays for passing to PLC, possibly
-        # mapping to integers if the Graph was renumbered.
-        # Allow the Graph renumber lookup (if renumbering was done) to check
-        # for invalid node IDs in ebunch.
-        u = G._list_to_nodearray(u)
-        v = G._list_to_nodearray(v)
-    except KeyError as n:
-        raise nx.NodeNotFound(f"Node {n} not in G.")
     else:
-        # If G was not renumbered, then the ebunch nodes must be explicitly
-        # checked (note: ebunch can be very large). If not done,
-        # plc.jaccard_coefficients() will accept node IDs not in the graph and
-        # return a coefficient of 0 for them, which is not compatible with NX.
-        #
-        # FIXME: Is there a better way to do this?  Is there a utility to check
-        # if a node ID is valid for the graph?
-        if not hasattr(G, "key_to_id") or G.key_to_id is None:
-            ebunch_nodes = cp.unique(cp.concatenate([u, v]))
-            graph_nodes = cp.unique(
-                cp.concatenate(
-                    [
-                        G.src_indices,
-                        G.dst_indices,
-                        G._node_ids if G._node_ids is not None else cp.ndarray(0),
-                    ]
-                )
-            )
-            invalid = cp.setdiff1d(ebunch_nodes, graph_nodes, assume_unique=True)
-            if len(invalid) > 0:
-                raise nx.NodeNotFound(f"Node {invalid.tolist()[0]} not in G.")
+        (u, v) = zip(*ebunch)
+        try:
+            # Convert the ebunch lists to cupy arrays for passing to PLC, possibly
+            # mapping to integers if the Graph was renumbered.
+            # Allow the Graph renumber lookup (if renumbering was done) to check
+            # for invalid node IDs in ebunch.
+            u_indices = G._list_to_nodearray(u)
+            v_indices = G._list_to_nodearray(v)
+        except KeyError as n:
+            raise nx.NodeNotFound(f"Node {n} not in G.")
 
-    # Note that Jaccard similarity must run on a symmetric graph.
-    # FIXME: PLC will symmetrize the graph if told to, but the symmetrize flag
-    # to _get_plc_graph() appears to symmetrize using cupy and does other
-    # things (cast to 64bit, etc.). Can we let PLC do the symmetrization if the
-    # symmetrize flag is set instead?
+        # If G was not renumbered, then the ebunch nodes must be explicitly
+        # checked. If not done, plc.jaccard_coefficients() will accept node IDs
+        # not in the graph and return a coefficient of 0 for them, which is not
+        # compatible with NX.
+        if (not hasattr(G, "key_to_id") or G.key_to_id is None) and (
+            (n := u_indices.max()) >= G._N
+            or (n := v_indices.max()) >= G._N
+            or (n := u_indices.min()) < 0
+            or (n := v_indices.min()) < 0
+        ):
+            raise nx.NodeNotFound(f"Node {n} not in G.")
+
     (u, v, p) = plc.jaccard_coefficients(
         resource_handle=plc.ResourceHandle(),
         graph=G._get_plc_graph(symmetrize=None),
-        first=u,
-        second=v,
+        first=u_indices,
+        second=v_indices,
         use_weight=False,
         do_expensive_check=False,
     )
@@ -89,11 +77,4 @@ def jaccard_coefficient(G, ebunch=None):
     v = G._nodearray_to_list(v)
     p = p.tolist()
 
-    # zip() returns a zip object, which is different than default NX but should
-    # still be valid since it's an iterator of 3-tuples.
     return zip(u, v, p)
-
-
-# @jaccard_coefficient._can_run is always True (default)
-
-# @jaccard_coefficient._should_run is always True (default)

--- a/nx_cugraph/algorithms/link_prediction.py
+++ b/nx_cugraph/algorithms/link_prediction.py
@@ -1,5 +1,3 @@
-import cupy as cp
-
 # Copyright (c) 2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +10,7 @@ import cupy as cp
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import cupy as cp
 import networkx as nx
 import pylibcugraph as plc
 
@@ -27,32 +26,6 @@ __all__ = [
 @not_implemented_for("multigraph")
 @networkx_algorithm(version_added="25.02", _plc="jaccard_coefficients")
 def jaccard_coefficient(G, ebunch=None):
-    """
-    Parameters
-    ----------
-    G : graph
-        A NetworkX or nx-cugraph undirected graph.
-
-    ebunch : iterable of node pairs, optional (default = None)
-        Jaccard coefficient will be computed for each pair of nodes
-        given in the iterable. The pairs must be given as 2-tuples
-        (u, v) where u and v are nodes in the graph. If ebunch is None
-        then all nonexistent edges in the graph will be used.
-
-    Returns
-    -------
-    piter : iterator
-        An iterator of 3-tuples in the form (u, v, p) where (u, v) is a
-        pair of nodes and p is their Jaccard coefficient.
-
-    Raises
-    ------
-    NetworkXNotImplemented
-        If `G` is a `DiGraph`, a `Multigraph` or a `MultiDiGraph`.
-
-    NodeNotFound
-        If `ebunch` has a node that is not in `G`.
-    """
     if ebunch is None:
         # FIXME: is there a more efficient way to do this (on GPU or
         # otherwise)?
@@ -75,6 +48,8 @@ def jaccard_coefficient(G, ebunch=None):
     else:
         # If G was not renumbered, then the ebunch nodes must be explicitly
         # checked.
+        # FIXME: Is there a more efficient way to do this? Should this be a
+        # utility (or is it already)?
         if not hasattr(G, "key_to_id") or G.key_to_id is None:
             ebunch_nodes = cp.unique(cp.concatenate([u, v]))
             graph_nodes = cp.unique(cp.concatenate([G.src_indices, G.dst_indices]))

--- a/nx_cugraph/algorithms/link_prediction.py
+++ b/nx_cugraph/algorithms/link_prediction.py
@@ -47,9 +47,12 @@ def jaccard_coefficient(G, ebunch=None):
         raise nx.NodeNotFound(f"Node {n} not in G.")
     else:
         # If G was not renumbered, then the ebunch nodes must be explicitly
-        # checked. Note: ebunch can be very large.
-        # FIXME: Is there a better way to do this? Should this be a utility (or
-        # is it already)?
+        # checked (note: ebunch can be very large).  plc.jaccard_coefficient()
+        # will accept node IDs that are not in the graph and return a
+        # coefficient of 0 for them.
+        #
+        # FIXME: Is there a better way to do this?  Should this be a utility
+        # (or is it already)?
         if not hasattr(G, "key_to_id") or G.key_to_id is None:
             ebunch_nodes = cp.unique(cp.concatenate([u, v]))
             graph_nodes = cp.unique(

--- a/nx_cugraph/algorithms/link_prediction.py
+++ b/nx_cugraph/algorithms/link_prediction.py
@@ -66,7 +66,7 @@ def jaccard_coefficient(G, ebunch=None):
 
     (u, v, p) = plc.jaccard_coefficients(
         resource_handle=plc.ResourceHandle(),
-        graph=G._get_plc_graph(symmetrize=None),
+        graph=G._get_plc_graph(),
         first=u_indices,
         second=v_indices,
         use_weight=False,

--- a/nx_cugraph/algorithms/link_prediction.py
+++ b/nx_cugraph/algorithms/link_prediction.py
@@ -1,0 +1,108 @@
+import cupy as cp
+
+# Copyright (c) 2025, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import networkx as nx
+import pylibcugraph as plc
+
+from nx_cugraph.convert import _to_undirected_graph
+from nx_cugraph.utils import networkx_algorithm, not_implemented_for
+
+__all__ = [
+    "jaccard_coefficient",
+]
+
+
+@not_implemented_for("directed")
+@not_implemented_for("multigraph")
+@networkx_algorithm(version_added="25.02", _plc="jaccard_coefficients")
+def jaccard_coefficient(G, ebunch=None):
+    """
+    Parameters
+    ----------
+    G : graph
+        A NetworkX or nx-cugraph undirected graph.
+
+    ebunch : iterable of node pairs, optional (default = None)
+        Jaccard coefficient will be computed for each pair of nodes
+        given in the iterable. The pairs must be given as 2-tuples
+        (u, v) where u and v are nodes in the graph. If ebunch is None
+        then all nonexistent edges in the graph will be used.
+
+    Returns
+    -------
+    piter : iterator
+        An iterator of 3-tuples in the form (u, v, p) where (u, v) is a
+        pair of nodes and p is their Jaccard coefficient.
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If `G` is a `DiGraph`, a `Multigraph` or a `MultiDiGraph`.
+
+    NodeNotFound
+        If `ebunch` has a node that is not in `G`.
+    """
+    if ebunch is None:
+        # FIXME: is there a more efficient way to do this (on GPU or
+        # otherwise)?
+        ebunch = list(nx.non_edges(G))
+        if not ebunch:
+            return iter([])
+
+    G = _to_undirected_graph(G)
+
+    (u, v) = zip(*ebunch)
+    try:
+        # Convert the ebunch lists to cupy arrays for passing to PLC, possibly
+        # mapping to integers if the Graph was renumbered on creation.
+        # Allow the Graph renumber lookup (if renumbering was done) to check
+        # for invalid node IDs in ebunch.
+        u = G._list_to_nodearray(u)
+        v = G._list_to_nodearray(v)
+    except KeyError as n:
+        raise nx.NodeNotFound(f"Node {n} not in G.")
+    else:
+        # If G was not renumbered, then the ebunch nodes must be explicitly
+        # checked.
+        if not hasattr(G, "key_to_id") or G.key_to_id is None:
+            ebunch_nodes = cp.unique(cp.concatenate([u, v]))
+            graph_nodes = cp.unique(cp.concatenate([G.src_indices, G.dst_indices]))
+            if invalid := cp.setdiff1d(ebunch_nodes, graph_nodes, assume_unique=True):
+                raise nx.NodeNotFound(f"Node {invalid.tolist()[0]} not in G.")
+
+    # Note that Jaccard similarity must run on a symmetric graph.
+    # FIXME: PLC will symmetrize the graph if told to, but the symmetrize flag
+    # to _get_plc_graph() does other things (cast to 64bit, etc.). Can we let
+    # PLC do the symmetrization if the symmetrize flag is set instead?
+    (u, v, p) = plc.jaccard_coefficients(
+        resource_handle=plc.ResourceHandle(),
+        graph=G._get_plc_graph(symmetrize=None),
+        first=u,
+        second=v,
+        use_weight=False,
+        do_expensive_check=False,
+    )
+
+    u = G._nodearray_to_list(u)
+    v = G._nodearray_to_list(v)
+    p = p.tolist()
+
+    # zip() returns a zip object, which is different than default NX but should
+    # still be valid since it's an iterator of 3-tuples.
+    return zip(u, v, p)
+
+
+# @jaccard_coefficient._can_run is always True (default)
+
+# @jaccard_coefficient._should_run is always True (default)

--- a/nx_cugraph/classes/graph.py
+++ b/nx_cugraph/classes/graph.py
@@ -1152,6 +1152,10 @@ class CudaGraph:
     def _list_to_nodearray(self, nodes: list[NodeKey]) -> cp.ndarray[IndexValue]:
         if (key_to_id := self.key_to_id) is not None:
             nodes = [key_to_id[node] for node in nodes]
+        else:
+            valids = [isinstance(n, int) and n >= 0 and n < self._N for n in nodes]
+            if not all(valids):
+                raise ValueError(nodes[valids.index(False)])
         return cp.array(nodes, dtype=index_dtype)
 
     def _nodearray_to_set(self, node_ids: cp.ndarray[IndexValue]) -> set[NodeKey]:

--- a/nx_cugraph/classes/graph.py
+++ b/nx_cugraph/classes/graph.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -1009,6 +1009,11 @@ class CudaGraph:
         dst_indices = self.dst_indices
         if switch_indices:
             src_indices, dst_indices = dst_indices, src_indices
+
+        # FIXME: the SGGraph constructor arg "symmetrize" will perform all
+        # symmetrization steps required by libcugraph. The edge_array check
+        # should be kept, but all other code in this `if` block should be
+        # removed if possible.
         if symmetrize is not None:
             if edge_array is not None:
                 raise NotImplementedError(

--- a/nx_cugraph/classes/graph.py
+++ b/nx_cugraph/classes/graph.py
@@ -1153,9 +1153,14 @@ class CudaGraph:
         if (key_to_id := self.key_to_id) is not None:
             nodes = [key_to_id[node] for node in nodes]
         else:
-            valids = [isinstance(n, int) and n >= 0 and n < self._N for n in nodes]
-            if not all(valids):
-                raise ValueError(nodes[valids.index(False)])
+            N = self._N
+            for node in nodes:
+                try:
+                    n = int(node)
+                except (TypeError, ValueError):
+                    raise KeyError(node) from None
+                if n != node or n < 0 or n >= N:
+                    raise KeyError(node)
         return cp.array(nodes, dtype=index_dtype)
 
     def _nodearray_to_set(self, node_ids: cp.ndarray[IndexValue]) -> set[NodeKey]:

--- a/nx_cugraph/tests/test_link_prediction.py
+++ b/nx_cugraph/tests/test_link_prediction.py
@@ -29,3 +29,17 @@ def test_no_nonexistent_edges_no_ebunch():
     result = nx.jaccard_coefficient(G)
     assert isinstance(result, Iterable)
     assert pytest.raises(StopIteration, next, result)
+
+
+def test_node_not_found_in_ebunch():
+    """Test that all nodes in ebunch are valid
+
+    Ensure function raises NodeNotFound for invalid nodes in ebunch.
+    """
+    G = nx.Graph([(0, 1), (1, 2)])
+    with pytest.raises(nx.NodeNotFound, match="Node A not in G."):
+        nx.jaccard_coefficient(G, [("A", 1)])
+    with pytest.raises(nx.NodeNotFound, match=r"Node \(1,\) not in G."):
+        nx.jaccard_coefficient(G, [(0, (1,))])
+    with pytest.raises(nx.NodeNotFound, match="Node 9999 not in G."):
+        nx.jaccard_coefficient(G, [(0, 9999)])

--- a/nx_cugraph/tests/test_link_prediction.py
+++ b/nx_cugraph/tests/test_link_prediction.py
@@ -37,7 +37,7 @@ def test_node_not_found_in_ebunch():
     Ensure function raises NodeNotFound for invalid nodes in ebunch.
     """
     G = nx.Graph([(0, 1), (1, 2)])
-    with pytest.raises(nx.NodeNotFound, match="Node A not in G."):
+    with pytest.raises(nx.NodeNotFound, match="Node [']*A[']* not in G."):
         nx.jaccard_coefficient(G, [("A", 1)])
     with pytest.raises(nx.NodeNotFound, match=r"Node \(1,\) not in G."):
         nx.jaccard_coefficient(G, [(0, (1,))])

--- a/nx_cugraph/tests/test_link_prediction.py
+++ b/nx_cugraph/tests/test_link_prediction.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections.abc import Iterable
+
+import networkx as nx
+import pytest
+
+# The tests in this file cover use cases unique to nx-cugraph.  If the coverage
+# here is not unique to nx-cugraph, consider moving those tests to the NetworkX
+# project.
+
+
+def test_no_nonexistent_edges_no_ebunch():
+    """Test no ebunch and G is fully connected
+
+    Ensure function returns iter([]) or equivalent due to no nonexistent edges.
+    """
+    G = nx.complete_graph(5)
+    result = nx.jaccard_coefficient(G)
+    assert isinstance(result, Iterable)
+    assert pytest.raises(StopIteration, next, result)


### PR DESCRIPTION
Adds support for `jaccard_coefficient` to nx-cugraph.

This includes a test, but relies largely on the existing test coverage provided by NetworkX. The test included here could (should) be submitted to NetworkX though in a separate PR, since it is not covering anything unique to nx-cugraph.

A benchmark is also included, with results showing 2-4X speedup. I've seen much, much larger speedup on a different graph (large movie review bipartite graph, showing 966s for NX, 2s for nx-cugraph = ~500X), so I need to investigate further.  This investigation need not prevent this PR from being merged now though.

![image](https://github.com/user-attachments/assets/3ceb7d62-50c4-437e-96d2-0ab452dd39d2)
