### PR TITLE
Add benchmark for `leiden_communities`

### DIFF
--- a/benchmarks/pytest-based/bench_algos.py
+++ b/benchmarks/pytest-based/bench_algos.py
@@ -319,6 +319,27 @@ def bench_louvain_communities(benchmark, graph_obj, backend_wrapper):
     assert type(result) is list
 
 
+@pytest.mark.skipif("not hasattr(nx.community, 'leiden_communities')")
+def bench_leiden_communities(benchmark, graph_obj, backend_wrapper):
+    G = get_graph_obj_for_benchmark(graph_obj, backend_wrapper)
+    # DiGraphs are not supported
+    if G.is_directed():
+        G = G.to_undirected()
+    if G.__networkx_backend__ not in nx.community.leiden_communities.backends:
+        pytest.skip(
+            reason=f"leiden_communities not implemented by {G.__networkx_backend__!r}"
+        )
+        return
+    result = benchmark.pedantic(
+        target=backend_wrapper(nx.community.leiden_communities),
+        args=(G,),
+        rounds=rounds,
+        iterations=iterations,
+        warmup_rounds=warmup_rounds,
+    )
+    assert type(result) is list
+
+
 def bench_degree_centrality(benchmark, graph_obj, backend_wrapper):
     G = get_graph_obj_for_benchmark(graph_obj, backend_wrapper)
     result = benchmark.pedantic(

--- a/benchmarks/pytest-based/run-main-benchmarks.sh
+++ b/benchmarks/pytest-based/run-main-benchmarks.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -58,8 +58,8 @@ fi
 
 for algo in $algos; do
     for dataset in $datasets; do
-	# this script can be used to download benchmarking datasets by name via cugraph.datasets
-    	python get_graph_bench_dataset.py $dataset
+        # this script can be used to download benchmarking datasets by name via cugraph.datasets
+        python get_graph_bench_dataset.py $dataset
         for backend in $backends; do
             name="${backend}__${algo}__${dataset}"
             echo "Running: $backend, $dataset, bench_$algo"


### PR DESCRIPTION
Here are results from a single round of benchmarks for louvain and leiden:
```
Name (time in ms)                                                                 Min
bench_leiden_communities[ds=karate-backend=cugraph-preconverted]              32.3493
bench_louvain_communities[ds=karate-backend=cugraph-preconverted]             15.2782
bench_leiden_communities[ds=netscience-backend=cugraph-preconverted]          83.5688
bench_louvain_communities[ds=netscience-backend=cugraph-preconverted]         34.1273
bench_leiden_communities[ds=email_Eu_core-backend=cugraph-preconverted]       81.3393
bench_louvain_communities[ds=email_Eu_core-backend=cugraph-preconverted]      50.0181
bench_leiden_communities[ds=amazon0302-backend=cugraph-preconverted]         755.0755
bench_louvain_communities[ds=amazon0302-backend=cugraph-preconverted]        939.3094

Name (time in s)                                                                  Min
bench_leiden_communities[ds=cit-patents-backend=cugraph-preconverted]          8.2224
bench_louvain_communities[ds=cit-patents-backend=cugraph-preconverted]         7.7888
bench_leiden_communities[ds=soc-livejournal1-backend=cugraph-preconverted]    16.1031
bench_louvain_communities[ds=soc-livejournal1-backend=cugraph-preconverted]   22.2967
bench_leiden_communities[ds=hollywood-backend=cugraph-preconverted]           22.7196
bench_louvain_communities[ds=hollywood-backend=cugraph-preconverted]          24.3643
bench_leiden_communities[ds=europe_osm-backend=cugraph-preconverted]          39.7309
bench_louvain_communities[ds=europe_osm-backend=cugraph-preconverted]         46.4452
```