### PR TITLE
Adds notebook for Jaccard Similarity

### DIFF
--- a/notebooks/demo/nx_cugraph_jaccard_movie_recommender.ipynb
+++ b/notebooks/demo/nx_cugraph_jaccard_movie_recommender.ipynb
@@ -179,6 +179,7 @@
     "                                \"timestamp\": \"int32\",\n",
     "                                }\n",
     "                         )\n",
+    "ratings_df['userId'][0]\n",
     "# Not using timestamp\n",
     "ratings_df.drop(columns=\"timestamp\", inplace=True)\n",
     "\n",
@@ -230,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 40,
    "id": "c2ab6169-37ab-4e78-b0ac-91289a7190c9",
    "metadata": {},
    "outputs": [
@@ -274,7 +275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 41,
    "id": "9fb98b4e-026c-4e39-8fec-88e53de4eac0",
    "metadata": {},
    "outputs": [],
@@ -293,7 +294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 47,
    "id": "764192e3-d865-4660-aa44-57eaa98eb5f6",
    "metadata": {},
    "outputs": [
@@ -301,7 +302,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "highest rated movie for user=np.int32(289308) is Mulan (1998), id: 1907, rated: {'rating': 5.0}\n"
+      "Highest rated movie for user 289308 is Mulan (1998), id: 1907, rated: 5.0\n"
      ]
     }
    ],
@@ -314,15 +315,15 @@
     "    key=lambda n: user_reviews[n].get(\"rating\", 0)\n",
     ")\n",
     "\n",
-    "print(f\"highest rated movie for {user=} is \"\n",
+    "print(f\"Highest rated movie for user {int(user)} is \"\n",
     "      f\"{movie_id_name_map[highest_rated_movie]}, \"\n",
     "      f\"id: {highest_rated_movie}, \"\n",
-    "      f\"rated: {user_reviews[highest_rated_movie]}\")"
+    "      f\"rated: {user_reviews[highest_rated_movie]['rating']}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 48,
    "id": "e1a73938-3ab9-4086-b820-7ae0aa4e8b94",
    "metadata": {},
    "outputs": [],
@@ -345,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 51,
    "id": "aacce305-c05f-4685-8cfe-08e0b48a7b80",
    "metadata": {},
    "outputs": [
@@ -353,8 +354,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 165 ms, sys: 8.1 ms, total: 173 ms\n",
-      "Wall time: 171 ms\n"
+      "CPU times: user 173 ms, sys: 4.07 ms, total: 177 ms\n",
+      "Wall time: 175 ms\n"
      ]
     }
    ],
@@ -405,7 +406,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 52,
    "id": "59aaf9db-d31d-435c-8a8d-c2f4f1c1446f",
    "metadata": {},
    "outputs": [
@@ -442,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 67,
    "id": "c3ad08a2-3f65-48ad-b43b-bb7ed767773e",
    "metadata": {},
    "outputs": [],
@@ -456,10 +457,10 @@
     "    jacc_coeffs = list(nx.jaccard_coefficient(good_user_movie_G, ebunch))\n",
     "\n",
     "    jacc_coeffs.sort(key=lambda t: t[2], reverse=True)\n",
-    "    print(f\"movies similar to {movie_id_name_map[movie_id]}:\")\n",
+    "    print(f\"Movies similar to {movie_id_name_map[movie_id]}:\")\n",
     "    for i in range(n):\n",
     "        (_, movieId, similarity) = jacc_coeffs[i]\n",
-    "        print(f\"{movieId=},\\t{movie_id_name_map[movieId]}\")"
+    "        print(f\"ID {int(movieId)}, {movie_id_name_map[movieId]}\")"
    ]
   },
   {
@@ -472,7 +473,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 68,
    "id": "eff63f64-2ee9-495c-856e-5278baa94d71",
    "metadata": {},
    "outputs": [
@@ -480,19 +481,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "movies similar to Mulan (1998):\n",
-      "movieId=np.int32(1566),\tHercules (1997)\n",
-      "movieId=np.int32(2687),\tTarzan (1999)\n",
-      "movieId=np.int32(4016),\t\"Emperor's New Groove, The (2000)\"\n",
-      "movieId=np.int32(2081),\t\"Little Mermaid, The (1989)\"\n",
-      "movieId=np.int32(5444),\tLilo & Stitch (2002)\n",
-      "movieId=np.int32(2078),\t\"Jungle Book, The (1967)\"\n",
-      "movieId=np.int32(2355),\t\"Bug's Life, A (1998)\"\n",
-      "movieId=np.int32(81847),\tTangled (2010)\n",
-      "movieId=np.int32(3114),\tToy Story 2 (1999)\n",
-      "movieId=np.int32(2096),\tSleeping Beauty (1959)\n",
-      "CPU times: user 1min 9s, sys: 324 ms, total: 1min 9s\n",
-      "Wall time: 1min 9s\n"
+      "Movies similar to Mulan (1998):\n",
+      "ID 1566, Hercules (1997)\n",
+      "ID 2687, Tarzan (1999)\n",
+      "ID 4016, \"Emperor's New Groove, The (2000)\"\n",
+      "ID 2081, \"Little Mermaid, The (1989)\"\n",
+      "ID 5444, Lilo & Stitch (2002)\n",
+      "ID 2078, \"Jungle Book, The (1967)\"\n",
+      "ID 2355, \"Bug's Life, A (1998)\"\n",
+      "ID 81847, Tangled (2010)\n",
+      "ID 3114, Toy Story 2 (1999)\n",
+      "ID 2096, Sleeping Beauty (1959)\n",
+      "CPU times: user 191 ms, sys: 12.3 ms, total: 203 ms\n",
+      "Wall time: 202 ms\n"
      ]
     }
    ],

--- a/notebooks/demo/nx_cugraph_jaccard_movie_recommender.ipynb
+++ b/notebooks/demo/nx_cugraph_jaccard_movie_recommender.ipynb
@@ -179,7 +179,7 @@
     "                                \"timestamp\": \"int32\",\n",
     "                                }\n",
     "                         )\n",
-    "ratings_df['userId'][0]\n",
+    "ratings_df[\"userId\"][0]\n",
     "# Not using timestamp\n",
     "ratings_df.drop(columns=\"timestamp\", inplace=True)\n",
     "\n",
@@ -361,7 +361,7 @@
    ],
    "source": [
     "%%time\n",
-    "# Run Jaccard Similarity \n",
+    "# Run Jaccard Similarity\n",
     "jacc_coeffs = list(nx.jaccard_coefficient(good_user_movie_G, ebunch))"
    ]
   },
@@ -392,7 +392,7 @@
    ],
    "source": [
     "%%time\n",
-    "# Run Jaccard Similarity \n",
+    "# Run Jaccard Similarity\n",
     "jacc_coeffs = list(nx.jaccard_coefficient(good_user_movie_G, ebunch, backend=\"networkx\"))"
    ]
   },
@@ -420,7 +420,7 @@
    ],
    "source": [
     "# Sort by coefficient value, which is the 3rd item in the tuples\n",
-    "jacc_coeffs.sort(key=lambda t: t[2], reverse=True)  \n",
+    "jacc_coeffs.sort(key=lambda t: t[2], reverse=True)\n",
     "\n",
     "# Create a list of recommendations ordered by \"best\" to \"worst\" based on the\n",
     "# Jaccard Similarity coefficients and the movies already seen\n",
@@ -669,7 +669,7 @@
     "print(f\"CPU: {cpu_name}\")\n",
     "if torch.cuda.is_available():\n",
     "    gpu_name = torch.cuda.get_device_name(0)\n",
-    "    gpu_memory = torch.cuda.get_device_properties(0).total_memory / (1024 ** 3) \n",
+    "    gpu_memory = torch.cuda.get_device_properties(0).total_memory / (1024 ** 3)\n",
     "    print(f\"GPU: {gpu_name}\")\n",
     "    print(f\"GPU Memory: {gpu_memory:.2f} GB\")"
    ]
@@ -677,7 +677,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "gnn",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/notebooks/demo/nx_cugraph_jaccard_movie_recommender.ipynb
+++ b/notebooks/demo/nx_cugraph_jaccard_movie_recommender.ipynb
@@ -1,8 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "baa01a86-37ad-4d78-bcfe-1469ee654510",
+   "metadata": {},
+   "source": [
+    "# A Movie Recommendation System Using Jaccard Similarity in NetworkX and the cuGraph Backend\n",
+    "This notebook demonstrates a simple and effective movie recommendation system based on MovieLens<sup>1</sup> data, the Jaccard Similarity algorithm in NetworkX, and the NVIDIA cuGraph backend to NetworkX (`nx-cugraph`) to provide GPU acceleration."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96e4df06-7876-4a4d-8949-c7d131b40c9f",
+   "metadata": {},
+   "source": [
+    "## Let's Get the Environment Setup\n",
+    "Let's begin by importing some modules from the standard library, and Pandas for reading in and preprocessing the MovieLens data."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "544b8e4c-2f07-41c1-a8f9-c4f648f8159f",
    "metadata": {},
    "outputs": [],
@@ -11,18 +29,114 @@
     "import requests\n",
     "from zipfile import ZipFile\n",
     "\n",
-    "# Prior to importing networkx, set the environment variable to enable nx-cugraph\n",
-    "# Note: this is done here for demonstration purposes but should be done in the\n",
-    "# calling environment to ensure the code is portable to systems without a GPU.\n",
-    "os.environ[\"NX_CUGRAPH_AUTOCONFIG\"] = \"True\"\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b6ebf2c-b26a-4b37-a61a-076e59d8ff3a",
+   "metadata": {},
+   "source": [
+    "`nx-cugraph` is available as a package installable using `pip`, `conda`, and [from source](https://github.com/rapidsai/nx-cugraph). Before importing `networkx`, lets install `nx-cugraph` so it can be registered as an available backend by NetworkX when needed. We'll use `pip` to install.\n",
     "\n",
-    "import pandas as pd\n",
-    "import networkx as nx"
+    "### NOTES:\n",
+    "* `nx-cugraph` requires a compatible NVIDIA GPU, NVIDIA CUDA, its associated drivers, and a supported OS. Details about these and other installation prerequisites can be seen [here](https://www.google.com/url?q=https%3A%2F%2Fdocs.rapids.ai%2Finstall%23system-req).\n",
+    "* The `nx-cugraph` package is currently hosted by NVIDIA, therefore the `--extra-index-url` option must be used.\n",
+    "* `nx-cugraph` is supported on specific 11.x and 12.x CUDA versions, and the major version number must be known in order to install the correct build (this is determined automatically when using `conda`).\n",
+    "\n",
+    "To find the CUDA major version on your system, run the following command:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7ad8b81e-b3e7-4f59-998c-ec800c3b99ce",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "nvcc: NVIDIA (R) Cuda compiler driver\n",
+      "Copyright (c) 2005-2022 NVIDIA Corporation\n",
+      "Built on Wed_Sep_21_10:33:58_PDT_2022\n",
+      "Cuda compilation tools, release 11.8, V11.8.89\n",
+      "Build cuda_11.8.r11.8/compiler.31833905_0\n"
+     ]
+    }
+   ],
+   "source": [
+    "!nvcc --version"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3d7feec-32fa-430e-87bf-4d385fa8eec6",
+   "metadata": {},
+   "source": [
+    "From the above output we can see that we're using CUDA 12.x so we'll be installing `nx-cugraph-cu12`. If we were using CUDA 11.x the package name would be `nx-cugraph-cu11`. Also note the additional index URLs specified using `--extra-index-url`:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "52c7d46f-8ec4-43ba-a1c3-e8c9d72a1394",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install \"nx-cugraph-cu12>=25.2.0a0\" --extra-index-url=https://pypi.nvidia.com --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09fe5880-dd19-4cea-abef-5054fec2efd8",
+   "metadata": {},
+   "source": [
+    "This notebook will be using features added in NetworkX 3.4, so we'll import it here to verify we have a compatible version.\n",
+    "\n",
+    "We'll also set the `NX_CUGRAPH_AUTOCONFIG` environment variable that is read by nx-cugraph (version 24.10 and newer) on initialization which will configure NetworkX to use the \"cugraph\" backend by default. This variable is unique to the cuGraph backend and must be set prior to importing networkx.\n",
+    "\n",
+    "Finally, this notebook will automatically use a NetworkX caching feature. This is enabled by default in NetworkX, but does produce a courtesy warning for certain users that modify the graph in ways no longer recommended. You can re-enable the warning to see more details, but this notebook uses only recommended APIs and the warning does not apply here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1cd431a9-ef4b-4bf6-a2ae-e85b1cc1bfd2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: NX_CUGRAPH_AUTOCONFIG=True\n",
+      "using networkx version 3.4.2\n"
+     ]
+    }
+   ],
+   "source": [
+    "%env NX_CUGRAPH_AUTOCONFIG=True\n",
+    "\n",
+    "import networkx as nx\n",
+    "print(f\"using networkx version {nx.__version__}\")\n",
+    "\n",
+    "nx.config.warnings_to_ignore.add(\"cache\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1db8c4ba-4b26-4eb2-8c0e-63e3e68d0480",
+   "metadata": {},
+   "source": [
+    "### The MovieLens dataset\n",
+    "The MovieLens dataset1 is generously made available for download to the public [here](https://files.grouplens.org/datasets/movielens/ml-latest.zip), and is described in more detail in the README file [here](https://files.grouplens.org/datasets/movielens/ml-latest-README.html). The full set includes approximately 331k anonymized users reviewing 87k movies, resulting in 34M ratings.\n",
+    "\n",
+    "Let's download the archive and extract the two files needed by this notebook:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "id": "e717c0c1-2510-4121-a1a2-6b8d695aff40",
    "metadata": {},
    "outputs": [],
@@ -43,8 +157,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6cc443bb-64b1-4f81-a729-ba377d9ce921",
+   "metadata": {},
+   "source": [
+    "### Reading the data\n",
+    "The ratings data is read in to a Pandas DataFrame for preprocessing."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "19ba9f34-820a-43ed-9f3b-6610f74e083f",
    "metadata": {},
    "outputs": [],
@@ -69,6 +192,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "dd89c470-16c7-43b7-b092-c17dc70ee536",
+   "metadata": {},
+   "source": [
+    "The movies CSV file contains a mapping from movie IDs to movie titles. It also contains the movie's genres, which will not be used in this notebook. The file will be read in and saved as a dictionary so movie titles can be easily retrieved using a movie ID."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "641b341f-05f7-4ac0-ba77-c42fc60b8e70",
@@ -90,16 +221,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "58c6b0dc-fa84-4cd7-b1ae-af1f10954867",
+   "metadata": {},
+   "source": [
+    "This creates a separate DataFrame containing only \"good\" reviews (rating >= 3), which is used for finding similarities between good movies for recommendations, since jaccard does not consider edge weights (rating value) and would otherwise treat bad reviews and good reviews equally."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "c2ab6169-37ab-4e78-b0ac-91289a7190c9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create a separate DataFrame containing only \"good\" reviews (rating >= 3).\n",
-    "# This is used for finding similarities between good movies for\n",
-    "# recommendations, since jaccard does not consider edge weights (rating value)\n",
-    "# and would otherwise treat bad reviews and good reviews equally.\n",
     "good_ratings_df = ratings_df[ratings_df[\"rating\"] >= 3]\n",
     "good_user_ids = good_ratings_df[\"userId\"].unique()\n",
     "good_movie_ids = good_ratings_df[\"movieId\"].unique()\n",
@@ -115,6 +250,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b0d193d1-369a-484f-8f36-8777a471a5f8",
+   "metadata": {},
+   "source": [
+    "The actual NetworkX graph object can now be created."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "9fb98b4e-026c-4e39-8fec-88e53de4eac0",
@@ -123,6 +266,14 @@
    "source": [
     "good_user_movie_G = nx.from_pandas_edgelist(\n",
     "    good_ratings_df, source=\"userId\", target=\"movieId\", edge_attr=\"rating\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e936c2f0-e718-4041-9bdb-139eb5460187",
+   "metadata": {},
+   "source": [
+    "A user can be chosen at random, and one of their highest rated movies can be picked. The idea is to find movies similar to a movie the user rated highly, then filter out movies the user has already seen and recommend the movie most similar to the highly rated one."
    ]
   },
   {
@@ -160,6 +311,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "98aa9dfa-9fee-460b-a3e9-e851570ed77d",
+   "metadata": {},
+   "source": [
+    "The Jaccard Similarity function provides the value used for measuring similarity. Jaccard similarity is described in more detail [here](https://en.wikipedia.org/wiki/Jaccard_index).\n",
+    "\n",
+    "Because the `NX_CUGRAPH_AUTOCONFIG` environment variable was set to `True`, NetworkX will use the Jaccard implementation provided by cuGraph."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "aacce305-c05f-4685-8cfe-08e0b48a7b80",
@@ -169,6 +330,36 @@
     "%%time\n",
     "# Run Jaccard Similarity \n",
     "jacc_coeffs = list(nx.jaccard_coefficient(good_user_movie_G, ebunch))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e510fe53-d04a-4ef3-b255-ccc2559af9c2",
+   "metadata": {},
+   "source": [
+    "The default NetworkX implementation can be used if specified using the `backend=` kwarg. This will override the backend priority set by the environemnt variable.\n",
+    "\n",
+    "Let's run using the default implementation to see how much time was saved using cuGraph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e9c80fb-05ee-4151-9c3d-64c778cc7560",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# Run Jaccard Similarity \n",
+    "jacc_coeffs = list(nx.jaccard_coefficient(good_user_movie_G, ebunch, backend=\"networkx\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4615d7a-7db9-4e0a-9e1e-4056bc69daba",
+   "metadata": {},
+   "source": [
+    "To provide recommendations for this user, the movies most similar to the movie they rated highly as returned by the call to `jaccard_coefficients()` and sorted by the Jaccard coefficient can be used. Movies already seen by the user are filtered out."
    ]
   },
   {
@@ -190,6 +381,14 @@
     "    mid = recommendations[0]\n",
     "    print(f\"User ID {user} might like {movie_id_name_map[mid]} \"\n",
     "          f\"(movie ID: {mid})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba4a0019-8877-4706-a1d2-469fd70efa6b",
+   "metadata": {},
+   "source": [
+    "To further demonstrate how effective Jaccard similarity can be --especially when used with the cuGraph backend-- a helper function can be created to find and print movie similarities."
    ]
   },
   {
@@ -319,6 +518,15 @@
     "%%time\n",
     "# 318: \"\"Shawshank Redemption, The (1994)\"\"\n",
     "print_similar_movies(318)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a5c8c9c-5779-439e-a8c8-357902bb59f0",
+   "metadata": {},
+   "source": [
+    "<br>\n",
+    "<sup>1</sup> F. Maxwell Harper and Joseph A. Konstan. 2015. The MovieLens Datasets: History and Context. ACM Transactions on Interactive Intelligent Systems (TiiS) 5, 4: 19:1–19:19. https://doi.org/10.1145/2827872"
    ]
   }
  ],

--- a/notebooks/demo/nx_cugraph_jaccard_movie_recommender.ipynb
+++ b/notebooks/demo/nx_cugraph_jaccard_movie_recommender.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "544b8e4c-2f07-41c1-a8f9-c4f648f8159f",
    "metadata": {},
    "outputs": [],
@@ -49,10 +49,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "7ad8b81e-b3e7-4f59-998c-ec800c3b99ce",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "nvcc: NVIDIA (R) Cuda compiler driver\n",
+      "Copyright (c) 2005-2024 NVIDIA Corporation\n",
+      "Built on Thu_Mar_28_02:18:24_PDT_2024\n",
+      "Cuda compilation tools, release 12.4, V12.4.131\n",
+      "Build cuda_12.4.r12.4/compiler.34097967_0\n"
+     ]
+    }
+   ],
    "source": [
     "!nvcc --version"
    ]
@@ -89,10 +101,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "1cd431a9-ef4b-4bf6-a2ae-e85b1cc1bfd2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: NX_CUGRAPH_AUTOCONFIG=True\n",
+      "using networkx version 3.4.2\n"
+     ]
+    }
+   ],
    "source": [
     "%env NX_CUGRAPH_AUTOCONFIG=True\n",
     "\n",
@@ -115,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "e717c0c1-2510-4121-a1a2-6b8d695aff40",
    "metadata": {},
    "outputs": [],
@@ -146,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "19ba9f34-820a-43ed-9f3b-6610f74e083f",
    "metadata": {},
    "outputs": [],
@@ -180,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "641b341f-05f7-4ac0-ba77-c42fc60b8e70",
    "metadata": {},
    "outputs": [],
@@ -204,15 +225,28 @@
    "id": "58c6b0dc-fa84-4cd7-b1ae-af1f10954867",
    "metadata": {},
    "source": [
-    "This creates a separate DataFrame containing only \"good\" reviews (rating &ge; 3), which is used for finding similarities between good movies for recommendations, since `jaccard_coefficients()` does not consider edge weights (rating value) and would otherwise treat bad reviews and good reviews equally."
+    "This creates a separate DataFrame containing only \"good\" reviews (rating &ge; 3), which is used for finding similarities between good movies for recommendations, since `jaccard_coefficient()` does not consider edge weights (rating value) and would otherwise treat bad reviews and good reviews equally."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "c2ab6169-37ab-4e78-b0ac-91289a7190c9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "total number of users: 330975\n",
+      "total number of reviews: 33832162\n",
+      "average number of total reviews/user: 102.22\n",
+      "total number of users with good ratings: 329127\n",
+      "total number of good reviews: 27782577\n",
+      "average number of good reviews/user: 84.41\n"
+     ]
+    }
+   ],
    "source": [
     "good_ratings_df = ratings_df[ratings_df[\"rating\"] >= 3]\n",
     "good_user_ids = good_ratings_df[\"userId\"].unique()\n",
@@ -233,14 +267,14 @@
    "id": "b0d193d1-369a-484f-8f36-8777a471a5f8",
    "metadata": {},
    "source": [
-    "## Running `jaccard_coefficients` to recommend movies\n",
+    "## Running `jaccard_coefficient` to recommend movies\n",
     "\n",
     "Now that the data is prepared, the actual NetworkX graph object can be created."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "9fb98b4e-026c-4e39-8fec-88e53de4eac0",
    "metadata": {},
    "outputs": [],
@@ -259,10 +293,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "764192e3-d865-4660-aa44-57eaa98eb5f6",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "highest rated movie for user=np.int32(289308) is Mulan (1998), id: 1907, rated: {'rating': 5.0}\n"
+     ]
+    }
+   ],
    "source": [
     "# Pick a user and one of their highly-rated movies\n",
     "user = good_user_ids[321]\n",
@@ -280,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "e1a73938-3ab9-4086-b820-7ae0aa4e8b94",
    "metadata": {},
    "outputs": [],
@@ -303,10 +345,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "aacce305-c05f-4685-8cfe-08e0b48a7b80",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 165 ms, sys: 8.1 ms, total: 173 ms\n",
+      "Wall time: 171 ms\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# Run Jaccard Similarity \n",
@@ -325,10 +376,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "4e9c80fb-05ee-4151-9c3d-64c778cc7560",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1min 5s, sys: 65 ms, total: 1min 5s\n",
+      "Wall time: 1min 5s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# Run Jaccard Similarity \n",
@@ -340,15 +400,23 @@
    "id": "d4615d7a-7db9-4e0a-9e1e-4056bc69daba",
    "metadata": {},
    "source": [
-    "To generate recommendations for this user, we identify the movies most similar to a movie they rated highly using `jaccard_coefficients()`. These movies are sorted by the Jaccard coefficient value, and any movies already seen by the user are filtered out."
+    "To generate recommendations for this user, we identify the movies most similar to a movie they rated highly using `jaccard_coefficient()`. These movies are sorted by the Jaccard coefficient value, and any movies already seen by the user are filtered out."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "59aaf9db-d31d-435c-8a8d-c2f4f1c1446f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "User ID 289308 might like Tarzan (1999) (movie ID: 2687)\n"
+     ]
+    }
+   ],
    "source": [
     "# Sort by coefficient value, which is the 3rd item in the tuples\n",
     "jacc_coeffs.sort(key=lambda t: t[2], reverse=True)  \n",
@@ -374,7 +442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "c3ad08a2-3f65-48ad-b43b-bb7ed767773e",
    "metadata": {},
    "outputs": [],
@@ -391,7 +459,7 @@
     "    print(f\"movies similar to {movie_id_name_map[movie_id]}:\")\n",
     "    for i in range(n):\n",
     "        (_, movieId, similarity) = jacc_coeffs[i]\n",
-    "        print(f\"{movieId=},\\t{movie_id_name_map[movieId]})\n"
+    "        print(f\"{movieId=},\\t{movie_id_name_map[movieId]}\")"
    ]
   },
   {
@@ -404,10 +472,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "eff63f64-2ee9-495c-856e-5278baa94d71",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "movies similar to Mulan (1998):\n",
+      "movieId=1566,\tHercules (1997)\n",
+      "movieId=2687,\tTarzan (1999)\n",
+      "movieId=4016,\t\"Emperor's New Groove, The (2000)\"\n",
+      "movieId=2081,\t\"Little Mermaid, The (1989)\"\n",
+      "movieId=5444,\tLilo & Stitch (2002)\n",
+      "movieId=2078,\t\"Jungle Book, The (1967)\"\n",
+      "movieId=2355,\t\"Bug's Life, A (1998)\"\n",
+      "movieId=81847,\tTangled (2010)\n",
+      "movieId=3114,\tToy Story 2 (1999)\n",
+      "movieId=2096,\tSleeping Beauty (1959)\n",
+      "CPU times: user 180 ms, sys: 15.6 ms, total: 196 ms\n",
+      "Wall time: 194 ms\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "print_similar_movies(highest_rated_movie)"
@@ -425,10 +513,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "36426fa1-b4ea-4762-bde7-8f2a18886184",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "movies similar to Mulan (1998):\n",
+      "movieId=np.int32(1566),\tHercules (1997)\n",
+      "movieId=np.int32(2687),\tTarzan (1999)\n",
+      "movieId=np.int32(4016),\t\"Emperor's New Groove, The (2000)\"\n",
+      "movieId=np.int32(2081),\t\"Little Mermaid, The (1989)\"\n",
+      "movieId=np.int32(5444),\tLilo & Stitch (2002)\n",
+      "movieId=np.int32(2078),\t\"Jungle Book, The (1967)\"\n",
+      "movieId=np.int32(2355),\t\"Bug's Life, A (1998)\"\n",
+      "movieId=np.int32(81847),\tTangled (2010)\n",
+      "movieId=np.int32(3114),\tToy Story 2 (1999)\n",
+      "movieId=np.int32(2096),\tSleeping Beauty (1959)\n",
+      "CPU times: user 1min 4s, sys: 116 ms, total: 1min 5s\n",
+      "Wall time: 1min 5s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "current_priority = nx.config.backend_priority\n",
@@ -439,10 +547,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "c296392e-0e60-4338-b602-2945c9fe0b33",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "movies similar to 101 Dalmatians (1996):\n",
+      "movieId=np.int32(2085),\t101 Dalmatians (One Hundred and One Dalmatians) (1961)\n",
+      "movieId=np.int32(783),\t\"Hunchback of Notre Dame, The (1996)\"\n",
+      "movieId=np.int32(837),\tMatilda (1996)\n",
+      "movieId=np.int32(673),\tSpace Jam (1996)\n",
+      "movieId=np.int32(1022),\tCinderella (1950)\n",
+      "movieId=np.int32(1029),\tDumbo (1941)\n",
+      "movieId=np.int32(2018),\tBambi (1942)\n",
+      "movieId=np.int32(2080),\tLady and the Tramp (1955)\n",
+      "movieId=np.int32(1032),\tAlice in Wonderland (1951)\n",
+      "movieId=np.int32(661),\tJames and the Giant Peach (1996)\n",
+      "CPU times: user 46.5 s, sys: 172 ms, total: 46.7 s\n",
+      "Wall time: 46.7 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# 1367: \"101 Dalmatians (1996)\"\n",
@@ -451,10 +579,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "e4b6a0f0-14de-47e1-8f7f-0a211178c509",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "movies similar to Star Wars: Episode V - The Empire Strikes Back (1980):\n",
+      "movieId=np.int32(260),\tStar Wars: Episode IV - A New Hope (1977)\n",
+      "movieId=np.int32(1210),\tStar Wars: Episode VI - Return of the Jedi (1983)\n",
+      "movieId=np.int32(1198),\tRaiders of the Lost Ark (Indiana Jones and the Raiders of the Lost Ark) (1981)\n",
+      "movieId=np.int32(2571),\t\"Matrix, The (1999)\"\n",
+      "movieId=np.int32(1291),\tIndiana Jones and the Last Crusade (1989)\n",
+      "movieId=np.int32(1270),\tBack to the Future (1985)\n",
+      "movieId=np.int32(1240),\t\"Terminator, The (1984)\"\n",
+      "movieId=np.int32(4993),\t\"Lord of the Rings: The Fellowship of the Ring, The (2001)\"\n",
+      "movieId=np.int32(1214),\tAlien (1979)\n",
+      "movieId=np.int32(5952),\t\"Lord of the Rings: The Two Towers, The (2002)\"\n",
+      "CPU times: user 4min 22s, sys: 309 ms, total: 4min 22s\n",
+      "Wall time: 4min 22s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# 1196: \"Star Wars: Episode V - The Empire Strikes Back (1980)\"\n",
@@ -463,10 +611,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "2911e5da-783b-4b48-8093-30295edc77a7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "movies similar to Tron (1982):\n",
+      "movieId=np.int32(2021),\tDune (1984)\n",
+      "movieId=np.int32(2985),\tRoboCop (1987)\n",
+      "movieId=np.int32(1374),\tStar Trek II: The Wrath of Khan (1982)\n",
+      "movieId=np.int32(2968),\tTime Bandits (1981)\n",
+      "movieId=np.int32(2193),\tWillow (1988)\n",
+      "movieId=np.int32(2640),\tSuperman (1978)\n",
+      "movieId=np.int32(2140),\t\"Dark Crystal, The (1982)\"\n",
+      "movieId=np.int32(1127),\t\"Abyss, The (1989)\"\n",
+      "movieId=np.int32(1375),\tStar Trek III: The Search for Spock (1984)\n",
+      "movieId=np.int32(3033),\tSpaceballs (1987)\n",
+      "CPU times: user 56.5 s, sys: 378 ms, total: 56.8 s\n",
+      "Wall time: 56.5 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# 2105: \"Tron (1982)\"\n",
@@ -475,10 +643,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "2dab0a8e-a77b-4e7a-9dae-d9282a426b9b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "movies similar to Donnie Darko (2001):\n",
+      "movieId=np.int32(7361),\tEternal Sunshine of the Spotless Mind (2004)\n",
+      "movieId=np.int32(4226),\tMemento (2000)\n",
+      "movieId=np.int32(3949),\tRequiem for a Dream (2000)\n",
+      "movieId=np.int32(6874),\tKill Bill: Vol. 1 (2003)\n",
+      "movieId=np.int32(7438),\tKill Bill: Vol. 2 (2004)\n",
+      "movieId=np.int32(4011),\tSnatch (2000)\n",
+      "movieId=np.int32(2959),\tFight Club (1999)\n",
+      "movieId=np.int32(2329),\tAmerican History X (1998)\n",
+      "movieId=np.int32(48394),\t\"Pan's Labyrinth (Laberinto del fauno, El) (2006)\"\n",
+      "movieId=np.int32(32587),\tSin City (2005)\n",
+      "CPU times: user 2min 36s, sys: 167 ms, total: 2min 37s\n",
+      "Wall time: 2min 37s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# 4878: \"Donnie Darko (2001)\"\n",
@@ -487,10 +675,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "d20e20f7-8302-4f5d-94bf-909aa3715728",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "movies similar to Forbidden Planet (1956):\n",
+      "movieId=np.int32(1253),\t\"Day the Earth Stood Still, The (1951)\"\n",
+      "movieId=np.int32(2664),\tInvasion of the Body Snatchers (1956)\n",
+      "movieId=np.int32(2662),\t\"War of the Worlds, The (1953)\"\n",
+      "movieId=np.int32(2009),\tSoylent Green (1973)\n",
+      "movieId=np.int32(2527),\tWestworld (1973)\n",
+      "movieId=np.int32(1334),\t\"Blob, The (1958)\"\n",
+      "movieId=np.int32(2528),\tLogan's Run (1976)\n",
+      "movieId=np.int32(1019),\t\"20,000 Leagues Under the Sea (1954)\"\n",
+      "movieId=np.int32(2287),\tThem! (1954)\n",
+      "movieId=np.int32(3959),\t\"Time Machine, The (1960)\"\n",
+      "CPU times: user 22.2 s, sys: 152 ms, total: 22.4 s\n",
+      "Wall time: 22.4 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# 1301: \"Forbidden Planet (1956)\"\n",
@@ -499,10 +707,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "cccd169e-ee6e-4734-9f8d-7f3fd7662fd4",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "movies similar to \"Secret of NIMH, The (1982)\":\n",
+      "movieId=np.int32(2141),\t\"American Tail, An (1986)\"\n",
+      "movieId=np.int32(2090),\t\"Rescuers, The (1977)\"\n",
+      "movieId=np.int32(2137),\tCharlotte's Web (1973)\n",
+      "movieId=np.int32(3034),\tRobin Hood (1973)\n",
+      "movieId=np.int32(2140),\t\"Dark Crystal, The (1982)\"\n",
+      "movieId=np.int32(1025),\t\"Sword in the Stone, The (1963)\"\n",
+      "movieId=np.int32(1967),\tLabyrinth (1986)\n",
+      "movieId=np.int32(2161),\t\"NeverEnding Story, The (1984)\"\n",
+      "movieId=np.int32(2096),\tSleeping Beauty (1959)\n",
+      "movieId=np.int32(2087),\tPeter Pan (1953)\n",
+      "CPU times: user 37.9 s, sys: 140 ms, total: 38 s\n",
+      "Wall time: 38 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# 2139: \"\"Secret of NIMH, The (1982)\"\"\n",
@@ -511,10 +739,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "id": "fd569826-109b-4e3a-92a2-6c3cfef659dd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "movies similar to Thor: The Dark World (2013):\n",
+      "movieId=np.int32(86332),\tThor (2011)\n",
+      "movieId=np.int32(102125),\tIron Man 3 (2013)\n",
+      "movieId=np.int32(122892),\tAvengers: Age of Ultron (2015)\n",
+      "movieId=np.int32(110102),\tCaptain America: The Winter Soldier (2014)\n",
+      "movieId=np.int32(88140),\tCaptain America: The First Avenger (2011)\n",
+      "movieId=np.int32(122900),\tAnt-Man (2015)\n",
+      "movieId=np.int32(103042),\tMan of Steel (2013)\n",
+      "movieId=np.int32(122920),\tCaptain America: Civil War (2016)\n",
+      "movieId=np.int32(95510),\t\"Amazing Spider-Man, The (2012)\"\n",
+      "movieId=np.int32(77561),\tIron Man 2 (2010)\n",
+      "CPU times: user 40.6 s, sys: 83.8 ms, total: 40.7 s\n",
+      "Wall time: 40.7 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# 106072: \"Thor: The Dark World (2013)\"\n",
@@ -523,10 +771,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "id": "be944ff6-40b1-4f94-be77-1a1d52a5ffaf",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "movies similar to \"Shawshank Redemption, The (1994)\":\n",
+      "movieId=np.int32(296),\tPulp Fiction (1994)\n",
+      "movieId=np.int32(593),\t\"Silence of the Lambs, The (1991)\"\n",
+      "movieId=np.int32(356),\tForrest Gump (1994)\n",
+      "movieId=np.int32(527),\tSchindler's List (1993)\n",
+      "movieId=np.int32(2571),\t\"Matrix, The (1999)\"\n",
+      "movieId=np.int32(50),\t\"Usual Suspects, The (1995)\"\n",
+      "movieId=np.int32(2959),\tFight Club (1999)\n",
+      "movieId=np.int32(47),\tSeven (a.k.a. Se7en) (1995)\n",
+      "movieId=np.int32(858),\t\"Godfather, The (1972)\"\n",
+      "movieId=np.int32(110),\tBraveheart (1995)\n",
+      "CPU times: user 6min 46s, sys: 367 ms, total: 6min 47s\n",
+      "Wall time: 6min 47s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# 318: \"\"Shawshank Redemption, The (1994)\"\"\n",
@@ -541,11 +809,54 @@
     "<br>\n",
     "<sup>1</sup> F. Maxwell Harper and Joseph A. Konstan. 2015. The MovieLens Datasets: History and Context. ACM Transactions on Interactive Intelligent Systems (TiiS) 5, 4: 19:1–19:19. https://doi.org/10.1145/2827872"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "189bbad9",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "### Hardware Information"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "e478180c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU: Intel(R) Xeon(R) CPU E5-2698 v4 @ 2.20GHz (40 cores)\n",
+      "GPU: Tesla V100-SXM2-32GB\n",
+      "GPU Memory: 31.74 GB\n"
+     ]
+    }
+   ],
+   "source": [
+    "# code used to retrieve CPU/GPU info\n",
+    "\n",
+    "import psutil\n",
+    "import torch\n",
+    "\n",
+    "with open(\"/proc/cpuinfo\") as f:\n",
+    "        cpu_name = next(line.strip().split(\": \")[1] for line in f if \"model name\" in line)\n",
+    "        cpu_name += f\" ({psutil.cpu_count(logical=False)} cores)\"\n",
+    "print(f\"CPU: {cpu_name}\")\n",
+    "if torch.cuda.is_available():\n",
+    "    gpu_name = torch.cuda.get_device_name(0)\n",
+    "    gpu_memory = torch.cuda.get_device_properties(0).total_memory / (1024 ** 3) \n",
+    "    print(f\"GPU: {gpu_name}\")\n",
+    "    print(f\"GPU Memory: {gpu_memory:.2f} GB\")"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "gnn",
    "language": "python",
    "name": "python3"
   },
@@ -559,7 +870,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/notebooks/demo/nx_cugraph_jaccard_movie_recommender.ipynb
+++ b/notebooks/demo/nx_cugraph_jaccard_movie_recommender.ipynb
@@ -14,7 +14,7 @@
    "id": "96e4df06-7876-4a4d-8949-c7d131b40c9f",
    "metadata": {},
    "source": [
-    "## Let's Get the Environment Setup\n",
+    "## Let's get the environment set up\n",
     "Let's begin by importing some modules from the standard library, and Pandas for reading in and preprocessing the MovieLens data."
    ]
   },
@@ -40,7 +40,7 @@
     "`nx-cugraph` is available as a package installable using `pip`, `conda`, and [from source](https://github.com/rapidsai/nx-cugraph). Before importing `networkx`, lets install `nx-cugraph` so it can be registered as an available backend by NetworkX when needed. We'll use `pip` to install.\n",
     "\n",
     "### NOTES:\n",
-    "* `nx-cugraph` requires a compatible NVIDIA GPU, NVIDIA CUDA, its associated drivers, and a supported OS. Details about these and other installation prerequisites can be seen [here](https://www.google.com/url?q=https%3A%2F%2Fdocs.rapids.ai%2Finstall%23system-req).\n",
+    "* `nx-cugraph` requires a compatible NVIDIA GPU, NVIDIA CUDA, its associated drivers, and a supported OS. Details about these and other installation prerequisites can be seen [here](https://docs.rapids.ai/install/system-req).\n",
     "* The `nx-cugraph` package is currently hosted by NVIDIA, therefore the `--extra-index-url` option must be used.\n",
     "* `nx-cugraph` is supported on specific 11.x and 12.x CUDA versions, and the major version number must be known in order to install the correct build (this is determined automatically when using `conda`).\n",
     "\n",
@@ -108,7 +108,7 @@
    "metadata": {},
    "source": [
     "### The MovieLens dataset\n",
-    "The MovieLens dataset1 is generously made available for download to the public [here](https://files.grouplens.org/datasets/movielens/ml-latest.zip), and is described in more detail in the README file [here](https://files.grouplens.org/datasets/movielens/ml-latest-README.html). The full set includes approximately 331k anonymized users reviewing 87k movies, resulting in 34M ratings.\n",
+    "The MovieLens dataset<sup>1</sup> is generously made available for download to the public [here](https://files.grouplens.org/datasets/movielens/ml-latest.zip), and is described in more detail in the README file [here](https://files.grouplens.org/datasets/movielens/ml-latest-README.html). The full set includes approximately 331k anonymized users reviewing 87k movies, resulting in 34M ratings.\n",
     "\n",
     "Let's download the archive and extract the two files needed by this notebook:"
    ]
@@ -141,7 +141,7 @@
    "metadata": {},
    "source": [
     "### Reading the data\n",
-    "The ratings data is read in to a Pandas DataFrame for preprocessing."
+    "The ratings data is read into a Pandas DataFrame for preprocessing."
    ]
   },
   {
@@ -204,7 +204,7 @@
    "id": "58c6b0dc-fa84-4cd7-b1ae-af1f10954867",
    "metadata": {},
    "source": [
-    "This creates a separate DataFrame containing only \"good\" reviews (rating >= 3), which is used for finding similarities between good movies for recommendations, since jaccard does not consider edge weights (rating value) and would otherwise treat bad reviews and good reviews equally."
+    "This creates a separate DataFrame containing only \"good\" reviews (rating &ge; 3), which is used for finding similarities between good movies for recommendations, since `jaccard_coefficients()` does not consider edge weights (rating value) and would otherwise treat bad reviews and good reviews equally."
    ]
   },
   {
@@ -233,7 +233,9 @@
    "id": "b0d193d1-369a-484f-8f36-8777a471a5f8",
    "metadata": {},
    "source": [
-    "The actual NetworkX graph object can now be created."
+    "## Running `jaccard_coefficients` to recommend movies\n",
+    "\n",
+    "Now that the data is prepared, the actual NetworkX graph object can be created."
    ]
   },
   {
@@ -252,7 +254,7 @@
    "id": "e936c2f0-e718-4041-9bdb-139eb5460187",
    "metadata": {},
    "source": [
-    "A user can be chosen at random, and one of their highest rated movies can be picked. The idea is to find movies similar to a movie the user rated highly, then filter out movies the user has already seen and recommend the movie most similar to the highly rated one."
+    "A random user is selected, and one of their highest-rated movies is chosen. The goal is to find movies similar to this highly-rated one, filter out movies the user has already seen, and recommend the most similar movie."
    ]
   },
   {
@@ -294,7 +296,7 @@
    "id": "98aa9dfa-9fee-460b-a3e9-e851570ed77d",
    "metadata": {},
    "source": [
-    "The Jaccard Similarity function provides the value used for measuring similarity. Jaccard similarity is described in more detail [here](https://en.wikipedia.org/wiki/Jaccard_index).\n",
+    "The Jaccard Similarity function calculates a value used for measuring similarity. Jaccard similarity is described in more detail [here](https://en.wikipedia.org/wiki/Jaccard_index).\n",
     "\n",
     "Because the `NX_CUGRAPH_AUTOCONFIG` environment variable was set to `True`, NetworkX will use the Jaccard implementation provided by cuGraph."
    ]
@@ -316,7 +318,7 @@
    "id": "e510fe53-d04a-4ef3-b255-ccc2559af9c2",
    "metadata": {},
    "source": [
-    "The default NetworkX implementation can be used if specified using the `backend=` kwarg. This will override the backend priority set by the environemnt variable.\n",
+    "The default NetworkX implementation can be used if specified using the `backend=` kwarg. This will override the backend priority set by the environment variable.\n",
     "\n",
     "Let's run using the default implementation to see how much time was saved using cuGraph."
    ]
@@ -338,7 +340,7 @@
    "id": "d4615d7a-7db9-4e0a-9e1e-4056bc69daba",
    "metadata": {},
    "source": [
-    "To provide recommendations for this user, the movies most similar to the movie they rated highly as returned by the call to `jaccard_coefficients()` and sorted by the Jaccard coefficient can be used. Movies already seen by the user are filtered out."
+    "To generate recommendations for this user, we identify the movies most similar to a movie they rated highly using `jaccard_coefficients()`. These movies are sorted by the Jaccard coefficient value, and any movies already seen by the user are filtered out."
    ]
   },
   {
@@ -367,7 +369,7 @@
    "id": "ba4a0019-8877-4706-a1d2-469fd70efa6b",
    "metadata": {},
    "source": [
-    "To further demonstrate how effective Jaccard similarity can be --especially when used with the cuGraph backend-- a helper function can be created to find and print movie similarities."
+    "To further demonstrate how effective Jaccard similarity can be&mdash;especially when used with the cuGraph backend&mdash;a helper function can be created to find and print movie similarities."
    ]
   },
   {
@@ -377,19 +379,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def print_similar_movies(movie_id, n=10, backend=\"networkx\"):\n",
+    "def print_similar_movies(movie_id, n=10):\n",
     "    # ebunch is the list of node pairs to generate Jaccard Similarity\n",
     "    # coefficients for. This will generate a list of comparisons between\n",
     "    # movie_id and every other movie in the graph\n",
     "    ebunch = [(movie_id, n) for n in good_movie_ids[1:] if n != movie_id]\n",
     "\n",
-    "    jacc_coeffs = list(nx.jaccard_coefficient(good_user_movie_G, ebunch, backend=backend))\n",
+    "    jacc_coeffs = list(nx.jaccard_coefficient(good_user_movie_G, ebunch))\n",
     "\n",
     "    jacc_coeffs.sort(key=lambda t: t[2], reverse=True)\n",
     "    print(f\"movies similar to {movie_id_name_map[movie_id]}:\")\n",
     "    for i in range(n):\n",
     "        (_, movieId, similarity) = jacc_coeffs[i]\n",
     "        print(f\"{movieId=},\\t{movie_id_name_map[movieId]})\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d87a464d-5766-43c4-9e29-375d2030dbc3",
+   "metadata": {},
+   "source": [
+    "The helper function can be used to show other movies similar to the highly-rated one."
    ]
   },
   {
@@ -401,6 +411,30 @@
    "source": [
     "%%time\n",
     "print_similar_movies(highest_rated_movie)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f9934f3-e376-47f9-adc7-3795f05ab2da",
+   "metadata": {},
+   "source": [
+    "The `nx.config` confguration namespace can also be used to configure which backend(s) NetworkX will use. This is another option when access to the NetworkX function is not available to pass a kwarg to, as is the case with our helper function. Keep in mind that the `backend=` kwarg will override this setting.\n",
+    "\n",
+    "Let's compare the performance of using the cuGraph backend to running with the default NetworkX implementation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36426fa1-b4ea-4762-bde7-8f2a18886184",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "current_priority = nx.config.backend_priority\n",
+    "nx.config.backend_priority=[\"networkx\"]\n",
+    "print_similar_movies(highest_rated_movie)\n",
+    "nx.config.backend_priority = current_priority"
    ]
   },
   {

--- a/notebooks/demo/nx_cugraph_jaccard_movie_recommender.ipynb
+++ b/notebooks/demo/nx_cugraph_jaccard_movie_recommender.ipynb
@@ -442,7 +442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 44,
    "id": "c3ad08a2-3f65-48ad-b43b-bb7ed767773e",
    "metadata": {},
    "outputs": [],
@@ -472,49 +472,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 45,
    "id": "eff63f64-2ee9-495c-856e-5278baa94d71",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "movies similar to Mulan (1998):\n",
-      "movieId=1566,\tHercules (1997)\n",
-      "movieId=2687,\tTarzan (1999)\n",
-      "movieId=4016,\t\"Emperor's New Groove, The (2000)\"\n",
-      "movieId=2081,\t\"Little Mermaid, The (1989)\"\n",
-      "movieId=5444,\tLilo & Stitch (2002)\n",
-      "movieId=2078,\t\"Jungle Book, The (1967)\"\n",
-      "movieId=2355,\t\"Bug's Life, A (1998)\"\n",
-      "movieId=81847,\tTangled (2010)\n",
-      "movieId=3114,\tToy Story 2 (1999)\n",
-      "movieId=2096,\tSleeping Beauty (1959)\n",
-      "CPU times: user 180 ms, sys: 15.6 ms, total: 196 ms\n",
-      "Wall time: 194 ms\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%time\n",
-    "print_similar_movies(highest_rated_movie)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5f9934f3-e376-47f9-adc7-3795f05ab2da",
-   "metadata": {},
-   "source": [
-    "The `nx.config` confguration namespace can also be used to configure which backend(s) NetworkX will use. This is another option when access to the NetworkX function is not available to pass a kwarg to, as is the case with our helper function. Keep in mind that the `backend=` kwarg will override this setting.\n",
-    "\n",
-    "Let's compare the performance of using the cuGraph backend to running with the default NetworkX implementation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "36426fa1-b4ea-4762-bde7-8f2a18886184",
    "metadata": {},
    "outputs": [
     {
@@ -532,45 +491,46 @@
       "movieId=np.int32(81847),\tTangled (2010)\n",
       "movieId=np.int32(3114),\tToy Story 2 (1999)\n",
       "movieId=np.int32(2096),\tSleeping Beauty (1959)\n",
-      "CPU times: user 1min 4s, sys: 116 ms, total: 1min 5s\n",
-      "Wall time: 1min 5s\n"
+      "CPU times: user 1min 9s, sys: 324 ms, total: 1min 9s\n",
+      "Wall time: 1min 9s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
+    "print_similar_movies(highest_rated_movie)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f9934f3-e376-47f9-adc7-3795f05ab2da",
+   "metadata": {},
+   "source": [
+    "The `nx.config` confguration namespace can also be used to configure which backend(s) NetworkX will use. This is another option when access to the NetworkX function is not available to pass a kwarg to, as is the case with our helper function. Keep in mind that the `backend=` kwarg will override this setting.\n",
+    "\n",
+    "Try running the following cells yourself to compare the difference in performance by using the cuGraph backend and the default NetworkX implementation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36426fa1-b4ea-4762-bde7-8f2a18886184",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
     "current_priority = nx.config.backend_priority\n",
-    "nx.config.backend_priority=[\"networkx\"]\n",
+    "nx.config.backend_priority=[\"cugraph\"] # select between 'networkx' and 'cugraph'\n",
     "print_similar_movies(highest_rated_movie)\n",
     "nx.config.backend_priority = current_priority"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "c296392e-0e60-4338-b602-2945c9fe0b33",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "movies similar to 101 Dalmatians (1996):\n",
-      "movieId=np.int32(2085),\t101 Dalmatians (One Hundred and One Dalmatians) (1961)\n",
-      "movieId=np.int32(783),\t\"Hunchback of Notre Dame, The (1996)\"\n",
-      "movieId=np.int32(837),\tMatilda (1996)\n",
-      "movieId=np.int32(673),\tSpace Jam (1996)\n",
-      "movieId=np.int32(1022),\tCinderella (1950)\n",
-      "movieId=np.int32(1029),\tDumbo (1941)\n",
-      "movieId=np.int32(2018),\tBambi (1942)\n",
-      "movieId=np.int32(2080),\tLady and the Tramp (1955)\n",
-      "movieId=np.int32(1032),\tAlice in Wonderland (1951)\n",
-      "movieId=np.int32(661),\tJames and the Giant Peach (1996)\n",
-      "CPU times: user 46.5 s, sys: 172 ms, total: 46.7 s\n",
-      "Wall time: 46.7 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "# 1367: \"101 Dalmatians (1996)\"\n",
@@ -579,30 +539,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "e4b6a0f0-14de-47e1-8f7f-0a211178c509",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "movies similar to Star Wars: Episode V - The Empire Strikes Back (1980):\n",
-      "movieId=np.int32(260),\tStar Wars: Episode IV - A New Hope (1977)\n",
-      "movieId=np.int32(1210),\tStar Wars: Episode VI - Return of the Jedi (1983)\n",
-      "movieId=np.int32(1198),\tRaiders of the Lost Ark (Indiana Jones and the Raiders of the Lost Ark) (1981)\n",
-      "movieId=np.int32(2571),\t\"Matrix, The (1999)\"\n",
-      "movieId=np.int32(1291),\tIndiana Jones and the Last Crusade (1989)\n",
-      "movieId=np.int32(1270),\tBack to the Future (1985)\n",
-      "movieId=np.int32(1240),\t\"Terminator, The (1984)\"\n",
-      "movieId=np.int32(4993),\t\"Lord of the Rings: The Fellowship of the Ring, The (2001)\"\n",
-      "movieId=np.int32(1214),\tAlien (1979)\n",
-      "movieId=np.int32(5952),\t\"Lord of the Rings: The Two Towers, The (2002)\"\n",
-      "CPU times: user 4min 22s, sys: 309 ms, total: 4min 22s\n",
-      "Wall time: 4min 22s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "# 1196: \"Star Wars: Episode V - The Empire Strikes Back (1980)\"\n",
@@ -611,30 +551,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "2911e5da-783b-4b48-8093-30295edc77a7",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "movies similar to Tron (1982):\n",
-      "movieId=np.int32(2021),\tDune (1984)\n",
-      "movieId=np.int32(2985),\tRoboCop (1987)\n",
-      "movieId=np.int32(1374),\tStar Trek II: The Wrath of Khan (1982)\n",
-      "movieId=np.int32(2968),\tTime Bandits (1981)\n",
-      "movieId=np.int32(2193),\tWillow (1988)\n",
-      "movieId=np.int32(2640),\tSuperman (1978)\n",
-      "movieId=np.int32(2140),\t\"Dark Crystal, The (1982)\"\n",
-      "movieId=np.int32(1127),\t\"Abyss, The (1989)\"\n",
-      "movieId=np.int32(1375),\tStar Trek III: The Search for Spock (1984)\n",
-      "movieId=np.int32(3033),\tSpaceballs (1987)\n",
-      "CPU times: user 56.5 s, sys: 378 ms, total: 56.8 s\n",
-      "Wall time: 56.5 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "# 2105: \"Tron (1982)\"\n",
@@ -643,30 +563,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "2dab0a8e-a77b-4e7a-9dae-d9282a426b9b",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "movies similar to Donnie Darko (2001):\n",
-      "movieId=np.int32(7361),\tEternal Sunshine of the Spotless Mind (2004)\n",
-      "movieId=np.int32(4226),\tMemento (2000)\n",
-      "movieId=np.int32(3949),\tRequiem for a Dream (2000)\n",
-      "movieId=np.int32(6874),\tKill Bill: Vol. 1 (2003)\n",
-      "movieId=np.int32(7438),\tKill Bill: Vol. 2 (2004)\n",
-      "movieId=np.int32(4011),\tSnatch (2000)\n",
-      "movieId=np.int32(2959),\tFight Club (1999)\n",
-      "movieId=np.int32(2329),\tAmerican History X (1998)\n",
-      "movieId=np.int32(48394),\t\"Pan's Labyrinth (Laberinto del fauno, El) (2006)\"\n",
-      "movieId=np.int32(32587),\tSin City (2005)\n",
-      "CPU times: user 2min 36s, sys: 167 ms, total: 2min 37s\n",
-      "Wall time: 2min 37s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "# 4878: \"Donnie Darko (2001)\"\n",
@@ -675,30 +575,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "d20e20f7-8302-4f5d-94bf-909aa3715728",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "movies similar to Forbidden Planet (1956):\n",
-      "movieId=np.int32(1253),\t\"Day the Earth Stood Still, The (1951)\"\n",
-      "movieId=np.int32(2664),\tInvasion of the Body Snatchers (1956)\n",
-      "movieId=np.int32(2662),\t\"War of the Worlds, The (1953)\"\n",
-      "movieId=np.int32(2009),\tSoylent Green (1973)\n",
-      "movieId=np.int32(2527),\tWestworld (1973)\n",
-      "movieId=np.int32(1334),\t\"Blob, The (1958)\"\n",
-      "movieId=np.int32(2528),\tLogan's Run (1976)\n",
-      "movieId=np.int32(1019),\t\"20,000 Leagues Under the Sea (1954)\"\n",
-      "movieId=np.int32(2287),\tThem! (1954)\n",
-      "movieId=np.int32(3959),\t\"Time Machine, The (1960)\"\n",
-      "CPU times: user 22.2 s, sys: 152 ms, total: 22.4 s\n",
-      "Wall time: 22.4 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "# 1301: \"Forbidden Planet (1956)\"\n",
@@ -707,30 +587,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "cccd169e-ee6e-4734-9f8d-7f3fd7662fd4",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "movies similar to \"Secret of NIMH, The (1982)\":\n",
-      "movieId=np.int32(2141),\t\"American Tail, An (1986)\"\n",
-      "movieId=np.int32(2090),\t\"Rescuers, The (1977)\"\n",
-      "movieId=np.int32(2137),\tCharlotte's Web (1973)\n",
-      "movieId=np.int32(3034),\tRobin Hood (1973)\n",
-      "movieId=np.int32(2140),\t\"Dark Crystal, The (1982)\"\n",
-      "movieId=np.int32(1025),\t\"Sword in the Stone, The (1963)\"\n",
-      "movieId=np.int32(1967),\tLabyrinth (1986)\n",
-      "movieId=np.int32(2161),\t\"NeverEnding Story, The (1984)\"\n",
-      "movieId=np.int32(2096),\tSleeping Beauty (1959)\n",
-      "movieId=np.int32(2087),\tPeter Pan (1953)\n",
-      "CPU times: user 37.9 s, sys: 140 ms, total: 38 s\n",
-      "Wall time: 38 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "# 2139: \"\"Secret of NIMH, The (1982)\"\"\n",
@@ -739,30 +599,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "fd569826-109b-4e3a-92a2-6c3cfef659dd",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "movies similar to Thor: The Dark World (2013):\n",
-      "movieId=np.int32(86332),\tThor (2011)\n",
-      "movieId=np.int32(102125),\tIron Man 3 (2013)\n",
-      "movieId=np.int32(122892),\tAvengers: Age of Ultron (2015)\n",
-      "movieId=np.int32(110102),\tCaptain America: The Winter Soldier (2014)\n",
-      "movieId=np.int32(88140),\tCaptain America: The First Avenger (2011)\n",
-      "movieId=np.int32(122900),\tAnt-Man (2015)\n",
-      "movieId=np.int32(103042),\tMan of Steel (2013)\n",
-      "movieId=np.int32(122920),\tCaptain America: Civil War (2016)\n",
-      "movieId=np.int32(95510),\t\"Amazing Spider-Man, The (2012)\"\n",
-      "movieId=np.int32(77561),\tIron Man 2 (2010)\n",
-      "CPU times: user 40.6 s, sys: 83.8 ms, total: 40.7 s\n",
-      "Wall time: 40.7 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "# 106072: \"Thor: The Dark World (2013)\"\n",
@@ -771,30 +611,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "be944ff6-40b1-4f94-be77-1a1d52a5ffaf",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "movies similar to \"Shawshank Redemption, The (1994)\":\n",
-      "movieId=np.int32(296),\tPulp Fiction (1994)\n",
-      "movieId=np.int32(593),\t\"Silence of the Lambs, The (1991)\"\n",
-      "movieId=np.int32(356),\tForrest Gump (1994)\n",
-      "movieId=np.int32(527),\tSchindler's List (1993)\n",
-      "movieId=np.int32(2571),\t\"Matrix, The (1999)\"\n",
-      "movieId=np.int32(50),\t\"Usual Suspects, The (1995)\"\n",
-      "movieId=np.int32(2959),\tFight Club (1999)\n",
-      "movieId=np.int32(47),\tSeven (a.k.a. Se7en) (1995)\n",
-      "movieId=np.int32(858),\t\"Godfather, The (1972)\"\n",
-      "movieId=np.int32(110),\tBraveheart (1995)\n",
-      "CPU times: user 6min 46s, sys: 367 ms, total: 6min 47s\n",
-      "Wall time: 6min 47s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "# 318: \"\"Shawshank Redemption, The (1994)\"\"\n",

--- a/notebooks/demo/nx_cugraph_jaccard_movie_recommender.ipynb
+++ b/notebooks/demo/nx_cugraph_jaccard_movie_recommender.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "544b8e4c-2f07-41c1-a8f9-c4f648f8159f",
    "metadata": {},
    "outputs": [],
@@ -49,22 +49,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "7ad8b81e-b3e7-4f59-998c-ec800c3b99ce",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "nvcc: NVIDIA (R) Cuda compiler driver\n",
-      "Copyright (c) 2005-2022 NVIDIA Corporation\n",
-      "Built on Wed_Sep_21_10:33:58_PDT_2022\n",
-      "Cuda compilation tools, release 11.8, V11.8.89\n",
-      "Build cuda_11.8.r11.8/compiler.31833905_0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!nvcc --version"
    ]
@@ -101,19 +89,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "1cd431a9-ef4b-4bf6-a2ae-e85b1cc1bfd2",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "env: NX_CUGRAPH_AUTOCONFIG=True\n",
-      "using networkx version 3.4.2\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%env NX_CUGRAPH_AUTOCONFIG=True\n",
     "\n",
@@ -136,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "e717c0c1-2510-4121-a1a2-6b8d695aff40",
    "metadata": {},
    "outputs": [],
@@ -167,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "19ba9f34-820a-43ed-9f3b-6610f74e083f",
    "metadata": {},
    "outputs": [],

--- a/notebooks/demo/nx_cugraph_jaccard_movie_recommender.ipynb
+++ b/notebooks/demo/nx_cugraph_jaccard_movie_recommender.ipynb
@@ -1,0 +1,346 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "544b8e4c-2f07-41c1-a8f9-c4f648f8159f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import requests\n",
+    "from zipfile import ZipFile\n",
+    "\n",
+    "# Prior to importing networkx, set the environment variable to enable nx-cugraph\n",
+    "# Note: this is done here for demonstration purposes but should be done in the\n",
+    "# calling environment to ensure the code is portable to systems without a GPU.\n",
+    "os.environ[\"NX_CUGRAPH_AUTOCONFIG\"] = \"True\"\n",
+    "\n",
+    "import pandas as pd\n",
+    "import networkx as nx"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e717c0c1-2510-4121-a1a2-6b8d695aff40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ratings_csv = \"ml-latest/ratings.csv\"\n",
+    "movies_csv = \"ml-latest/movies.csv\"\n",
+    "\n",
+    "if not os.path.exists(ratings_csv) or not os.path.exists(movies_csv):\n",
+    "    zip_file = \"ml-latest.zip\"\n",
+    "    if not os.path.exists(zip_file):\n",
+    "        req = requests.get(\n",
+    "            \"https://files.grouplens.org/datasets/movielens/\" + zip_file)\n",
+    "        with open(zip_file, \"wb\") as f:\n",
+    "            f.write(req.content)\n",
+    "    with ZipFile(zip_file, \"r\") as z:\n",
+    "        z.extract(ratings_csv)\n",
+    "        z.extract(movies_csv)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19ba9f34-820a-43ed-9f3b-6610f74e083f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ratings_df = pd.read_csv(ratings_csv,\n",
+    "                         dtype={\"userId\": \"int32\",\n",
+    "                                \"movieId\": \"int32\",\n",
+    "                                \"rating\": \"float32\",\n",
+    "                                \"timestamp\": \"int32\",\n",
+    "                                }\n",
+    "                         )\n",
+    "# Not using timestamp\n",
+    "ratings_df.drop(columns=\"timestamp\", inplace=True)\n",
+    "\n",
+    "# Both user and movie IDs start at 1\n",
+    "# Add offset to make userId and movieId values unique\n",
+    "max_movie_id = int(ratings_df[\"movieId\"].max())\n",
+    "ratings_df[\"userId\"] = ratings_df[\"userId\"] + max_movie_id\n",
+    "\n",
+    "all_user_ids = ratings_df[\"userId\"].unique()\n",
+    "all_movie_ids = ratings_df[\"movieId\"].unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "641b341f-05f7-4ac0-ba77-c42fc60b8e70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "movie_id_name_map = {}\n",
+    "with open(movies_csv) as f:\n",
+    "    for line in f.readlines():\n",
+    "        # Line format is: id,title,genres\n",
+    "        # Title may have \",\" in them, and will be in quotes if so\n",
+    "        items = line.split(\",\")\n",
+    "        try:\n",
+    "            mid = int(items[0])\n",
+    "        except ValueError:\n",
+    "            continue\n",
+    "        mname = \",\".join(items[1:-1])\n",
+    "        movie_id_name_map[mid] = mname"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2ab6169-37ab-4e78-b0ac-91289a7190c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a separate DataFrame containing only \"good\" reviews (rating >= 3).\n",
+    "# This is used for finding similarities between good movies for\n",
+    "# recommendations, since jaccard does not consider edge weights (rating value)\n",
+    "# and would otherwise treat bad reviews and good reviews equally.\n",
+    "good_ratings_df = ratings_df[ratings_df[\"rating\"] >= 3]\n",
+    "good_user_ids = good_ratings_df[\"userId\"].unique()\n",
+    "good_movie_ids = good_ratings_df[\"movieId\"].unique()\n",
+    "\n",
+    "print(f\"total number of users: {len(all_user_ids)}\")\n",
+    "print(f\"total number of reviews: {len(ratings_df)}\")\n",
+    "print(\"average number of total reviews/user: \"\n",
+    "      f\"{len(ratings_df)/len(all_user_ids):.2f}\")\n",
+    "print(f\"total number of users with good ratings: {len(good_user_ids)}\")\n",
+    "print(f\"total number of good reviews: {len(good_ratings_df)}\")\n",
+    "print(\"average number of good reviews/user: \"\n",
+    "      f\"{len(good_ratings_df)/len(good_user_ids):.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9fb98b4e-026c-4e39-8fec-88e53de4eac0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "good_user_movie_G = nx.from_pandas_edgelist(\n",
+    "    good_ratings_df, source=\"userId\", target=\"movieId\", edge_attr=\"rating\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "764192e3-d865-4660-aa44-57eaa98eb5f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pick a user and one of their highly-rated movies\n",
+    "user = good_user_ids[321]\n",
+    "user_reviews = good_user_movie_G[user]\n",
+    "highest_rated_movie = max(\n",
+    "    user_reviews,\n",
+    "    key=lambda n: user_reviews[n].get(\"rating\", 0)\n",
+    ")\n",
+    "\n",
+    "print(f\"highest rated movie for {user=} is \"\n",
+    "      f\"{movie_id_name_map[highest_rated_movie]}, \"\n",
+    "      f\"id: {highest_rated_movie}, \"\n",
+    "      f\"rated: {user_reviews[highest_rated_movie]}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1a73938-3ab9-4086-b820-7ae0aa4e8b94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a list of nodes to compare the user's highest\n",
+    "# rated movie to all other movies in the graph.\n",
+    "ebunch = [(highest_rated_movie, n) for n in good_movie_ids[1:]\n",
+    "          if n != highest_rated_movie]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aacce305-c05f-4685-8cfe-08e0b48a7b80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# Run Jaccard Similarity \n",
+    "jacc_coeffs = list(nx.jaccard_coefficient(good_user_movie_G, ebunch))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59aaf9db-d31d-435c-8a8d-c2f4f1c1446f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sort by coefficient value, which is the 3rd item in the tuples\n",
+    "jacc_coeffs.sort(key=lambda t: t[2], reverse=True)  \n",
+    "\n",
+    "# Create a list of recommendations ordered by \"best\" to \"worst\" based on the\n",
+    "# Jaccard Similarity coefficients and the movies already seen\n",
+    "movies_seen = list(good_user_movie_G.neighbors(user))\n",
+    "recommendations = [mid for (_, mid, _) in jacc_coeffs\n",
+    "                   if mid not in movies_seen]\n",
+    "if len(recommendations) > 0:\n",
+    "    mid = recommendations[0]\n",
+    "    print(f\"User ID {user} might like {movie_id_name_map[mid]} \"\n",
+    "          f\"(movie ID: {mid})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3ad08a2-3f65-48ad-b43b-bb7ed767773e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def print_similar_movies(movie_id, n=10, backend=\"networkx\"):\n",
+    "    # ebunch is the list of node pairs to generate Jaccard Similarity\n",
+    "    # coefficients for. This will generate a list of comparisons between\n",
+    "    # movie_id and every other movie in the graph\n",
+    "    ebunch = [(movie_id, n) for n in good_movie_ids[1:] if n != movie_id]\n",
+    "\n",
+    "    jacc_coeffs = list(nx.jaccard_coefficient(good_user_movie_G, ebunch, backend=backend))\n",
+    "\n",
+    "    jacc_coeffs.sort(key=lambda t: t[2], reverse=True)\n",
+    "    print(f\"movies similar to {movie_id_name_map[movie_id]}:\")\n",
+    "    for i in range(n):\n",
+    "        (_, movieId, similarity) = jacc_coeffs[i]\n",
+    "        print(f\"{movieId=},\\t{movie_id_name_map[movieId]})\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eff63f64-2ee9-495c-856e-5278baa94d71",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "print_similar_movies(highest_rated_movie)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c296392e-0e60-4338-b602-2945c9fe0b33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# 1367: \"101 Dalmatians (1996)\"\n",
+    "print_similar_movies(1367)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4b6a0f0-14de-47e1-8f7f-0a211178c509",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# 1196: \"Star Wars: Episode V - The Empire Strikes Back (1980)\"\n",
+    "print_similar_movies(1196)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2911e5da-783b-4b48-8093-30295edc77a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# 2105: \"Tron (1982)\"\n",
+    "print_similar_movies(2105)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2dab0a8e-a77b-4e7a-9dae-d9282a426b9b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# 4878: \"Donnie Darko (2001)\"\n",
+    "print_similar_movies(4878)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d20e20f7-8302-4f5d-94bf-909aa3715728",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# 1301: \"Forbidden Planet (1956)\"\n",
+    "print_similar_movies(1301)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cccd169e-ee6e-4734-9f8d-7f3fd7662fd4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# 2139: \"\"Secret of NIMH, The (1982)\"\"\n",
+    "print_similar_movies(2139)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd569826-109b-4e3a-92a2-6c3cfef659dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# 106072: \"Thor: The Dark World (2013)\"\n",
+    "print_similar_movies(106072)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be944ff6-40b1-4f94-be77-1a1d52a5ffaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# 318: \"\"Shawshank Redemption, The (1994)\"\"\n",
+    "print_similar_movies(318)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds a notebook to demonstrate nx-cugraph's support for `nx.jaccard_coefficients()` by implementing a simple movie recommendation system based on MovieLens data.

This notebook will also be made available in Google Colab and referenced in an upcoming blog.