### PR TITLE
add cugraph-notebook-codeowners to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,4 +28,4 @@ python/            @rapidsai/nx-cugraph-python-codeowners
 pyproject.toml     @rapidsai/packaging-codeowners
 
 # notebooks code owners
-*.ipynb @cugraph-notebook-codeowners
+*.ipynb @rapidsai/cugraph-notebook-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,3 +26,6 @@ python/            @rapidsai/nx-cugraph-python-codeowners
 /dependencies.yaml @rapidsai/packaging-codeowners
 /build.sh          @rapidsai/packaging-codeowners
 pyproject.toml     @rapidsai/packaging-codeowners
+
+# notebooks code owners
+*.ipynb @cugraph-notebook-codeowners


### PR DESCRIPTION
Makes all `.ipynb` files reviewable by `@cugraph-notebook-codeowners`