### PR TITLE
Initial implementation of `nx_cugraph.accel`

### DIFF
--- a/_nx_cugraph/__init__.py
+++ b/_nx_cugraph/__init__.py
@@ -313,6 +313,7 @@ def get_info():
     # Enable zero-code change usage with a simple environment variable
     # by setting or updating other NETWORKX environment variables.
     if os.environ.get("NX_CUGRAPH_AUTOCONFIG", "").strip().lower() == "true":
+        # See also `nx_cugraph.accel.install`, which updates `nx.config` at runtime
         from itertools import chain
 
         def update_env_var(varname):

--- a/nx_cugraph/__init__.py
+++ b/nx_cugraph/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -17,7 +17,7 @@ from _nx_cugraph import _check_networkx_version
 
 _nxver: tuple[int, int] | tuple[int, int, int] = _check_networkx_version()
 
-from . import utils
+from . import accel, utils
 
 from . import classes
 from .classes import *

--- a/nx_cugraph/accel/__init__.py
+++ b/nx_cugraph/accel/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .core import install
+from .magics import load_ipython_extension

--- a/nx_cugraph/accel/core.py
+++ b/nx_cugraph/accel/core.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import networkx as nx
+
+from nx_cugraph import _nxver
+
+
+def install():
+    """Enable NetworkX acceleration with nx-cugraph."""
+
+    # See also handling of NX_CUGRAPH_AUTOCONFIG env var in _nx_cugraph/__init__.py
+    def update_priority(priority):
+        while priority and "cugraph" in priority:
+            priority.remove("cugraph")
+        priority.insert(0, "cugraph")
+
+    if _nxver < (3, 3):
+        # No config available; modify internal state.
+        update_priority(nx.utils._dispatch._automatic_backends)
+        nx.utils._dispatch._fallback_to_nx = True
+        return
+        # Or we could raise...
+        # raise RuntimeError(
+        #     f"NetworkX version {_nxver} not supported by `nx_cugraph.accel.install`; "
+        #     "NetworkX version 3.3 or greater is required for this functionality."
+        # )
+
+    cfg = nx.config
+    if isinstance(cfg.backend_priority, list):
+        update_priority(cfg.backend_priority)
+    else:
+        update_priority(cfg.backend_priority.algos)
+        update_priority(cfg.backend_priority.generators)
+    if "fallback_to_nx" in cfg:
+        cfg.fallback_to_nx = True
+    if "cache_converted_graphs" in cfg:
+        cfg.cache_converted_graphs = True
+    nx.config.backends.cugraph.use_compat_graphs = True

--- a/nx_cugraph/accel/magics.py
+++ b/nx_cugraph/accel/magics.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .core import install
+
+
+def load_ipython_extension(ip):
+    install()


### PR DESCRIPTION
This aims to provide a similar UX as `cuml.accel` and `cudf.pandas`.

They both use `install()`, which we follow as `nxcg.accel.install()`, but I would have preferred `enable()` and `disable()`.

Also, `%load_ext nx_cugraph.accel` to set networkx config in IPython and Jupyter. This is like `%load_ext cuml.accel` and `%load_ext cudf.pandas`.

Not yet supported:
- `python -m nx_cugraph.accel script.py`
- `pytest_load_initial_conftests`
- Profiling