### PR TITLE
Update docs for BC

### DIFF
--- a/_nx_cugraph/__init__.py
+++ b/_nx_cugraph/__init__.py
@@ -174,7 +174,15 @@ _info = {
         "average_clustering": "Directed graphs and `weight` parameter are not yet supported.",
         "bellman_ford_path": "Negative cycles are not yet supported. ``NotImplementedError`` will be raised if there are negative edge weights. We plan to support negative edge weights soon. Also, callable ``weight`` argument is not supported.",
         "bellman_ford_path_length": "Negative cycles are not yet supported. ``NotImplementedError`` will be raised if there are negative edge weights. We plan to support negative edge weights soon. Also, callable ``weight`` argument is not supported.",
-        "betweenness_centrality": "`weight` parameter is not yet supported, and RNG with seed may be different. Normalization matches NetworkX version 3.5, which fixed normalization when using k (see https://github.com/networkx/networkx/pull/7908 for details).",
+        "betweenness_centrality": (
+            "`weight` parameter is not yet supported, and RNG with seed may be different.\n"
+            "Normalization when using k and endpoints=False does not currently match\n"
+            "NetworkX. nx-cugraph was updated in 25.04 to match\n"
+            "https://github.com/networkx/networkx/pull/7908, but does not yet match\n"
+            "https://github.com/networkx/networkx/pull/7949. These changes\n"
+            "were introduced in NetworkX 3.5. The next release of nx-cugraph, 25.06,\n"
+            "will match NetworkX 3.5."
+        ),
         "bfs_edges": "`sort_neighbors` parameter is not yet supported.",
         "bfs_predecessors": "`sort_neighbors` parameter is not yet supported.",
         "bfs_successors": "`sort_neighbors` parameter is not yet supported.",

--- a/nx_cugraph/algorithms/centrality/betweenness.py
+++ b/nx_cugraph/algorithms/centrality/betweenness.py
@@ -14,34 +14,29 @@ import cupy as cp
 import pylibcugraph as plc
 from networkx.utils import create_py_random_state
 
-from nx_cugraph import _nxver
 from nx_cugraph.convert import _to_graph
 from nx_cugraph.utils import index_dtype, networkx_algorithm
 
 __all__ = ["betweenness_centrality", "edge_betweenness_centrality"]
 
 
-if _nxver < (3, 5):
-    EXTRA_DOCSTRING = (
-        " Normalization matches NetworkX version 3.5, which fixed normalization when "
-        "using k (see https://github.com/networkx/networkx/pull/7908 for details)."
-    )
-else:
-    EXTRA_DOCSTRING = ""
-
-
 @networkx_algorithm(
     is_incomplete=True,  # weight not supported
     version_added="23.10",
     _plc="betweenness_centrality",
-    docstring=(
-        "`weight` parameter is not yet supported, and RNG with seed may be different."
-        f"{EXTRA_DOCSTRING}"
-    ),
 )
 def betweenness_centrality(
     G, k=None, normalized=True, weight=None, endpoints=False, seed=None
 ):
+    """
+    `weight` parameter is not yet supported, and RNG with seed may be different.
+    Normalization when using k and endpoints=False does not currently match
+    NetworkX. nx-cugraph was updated in 25.04 to match
+    https://github.com/networkx/networkx/pull/7908, but does not yet match
+    https://github.com/networkx/networkx/pull/7949. These changes
+    were introduced in NetworkX 3.5. The next release of nx-cugraph, 25.06,
+    will match NetworkX 3.5.
+    """
     if weight is not None:
         raise NotImplementedError(
             "Weighted implementation of betweenness centrality not currently supported"


### PR DESCRIPTION
Update note about `betweenness_centrality`, because libcugraph was updated to match  https://github.com/networkx/networkx/pull/7908, but does not yet match https://github.com/networkx/networkx/pull/7949.