### PR TITLE
Quote head_rev in conda recipes

### DIFF
--- a/conda/recipes/nx-cugraph/recipe.yaml
+++ b/conda/recipes/nx-cugraph/recipe.yaml
@@ -8,7 +8,7 @@ context:
   date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
   py_version: ${{ env.get("RAPIDS_PY_VERSION") }}
   py_buildstring: ${{ py_version | version_to_buildstring }}
-  head_rev: ${{ git.head_rev(".")[:8] }}
+  head_rev: '${{ git.head_rev(".")[:8] }}'
 
 package:
   name: nx-cugraph


### PR DESCRIPTION
This quotes `head_rev` to ensure that commits with leading zeros in the git SHA include those zeros in the output package name.

xref: https://github.com/rapidsai/build-planning/issues/176
