### PR TITLE
use 'rapids-init-pip' in wheel CI, other CI changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ jobs:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
+      script: ci/build_python.sh
       sha: ${{ inputs.sha }}
   upload-conda:
     needs: conda-python-build

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,10 +33,12 @@ jobs:
           - '**'
           - '!.devcontainer/**'
           - '!README.md'
+          - '!ci/release/update-version.sh'
         test_python:
           - '**'
           - '!.devcontainer/**'
           - '!README.md'
+          - '!ci/release/update-version.sh'
           - '!notebooks/**'
   devcontainer:
     secrets: inherit
@@ -59,6 +61,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.06
     with:
       build_type: pull-request
+      script: ci/build_python.sh
   conda-python-tests:
     needs: [conda-python-build, changed-files]
     secrets: inherit
@@ -67,6 +70,7 @@ jobs:
     with:
       build_type: pull-request
       run_codecov: false
+      script: ci/test_python.sh
   wheel-build-nx-cugraph:
     needs: [checks]
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,7 @@ jobs:
       # This selects "ARCH=amd64 + the latest supported Python, 1 job per major CUDA version".
       matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
       run_codecov: false
+      script: ci/test_python.sh
   wheel-tests-nx-cugraph:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -7,6 +7,7 @@ package_name=$1
 package_dir=$2
 
 source rapids-date-string
+source rapids-init-pip
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 

--- a/ci/build_wheel_nx-cugraph.sh
+++ b/ci/build_wheel_nx-cugraph.sh
@@ -3,5 +3,7 @@
 
 set -euo pipefail
 
+source rapids-init-pip
+
 ./ci/build_wheel.sh nx-cugraph .
 ./ci/validate_wheel.sh "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"

--- a/ci/test_wheel_nx-cugraph.sh
+++ b/ci/test_wheel_nx-cugraph.sh
@@ -3,10 +3,11 @@
 
 set -eoxu pipefail
 
+source rapids-init-pip
+
 package_name="nx-cugraph"
 python_package_name=${package_name//-/_}
 
-mkdir -p ./dist
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 
 # nx-cugraph is a pure wheel, which is part of generating the download path


### PR DESCRIPTION
## Description

Proposes a batch of small, mostly-unrelated changes to building and packaging.

These are all part of RAPIDS-wide efforts to make it easier to reproduce CI locally and to use artifacts from one project's CI in another project's CI.

Contributes to https://github.com/rapidsai/build-planning/issues/178

* prevents triggering expensive CI jobs based on PRs modifying `ci/release/update-version.sh`

Contributes to https://github.com/rapidsai/shared-workflows/issues/356

* explicitly provides an input for `script` to workflows using it, instead of relying on a default value coming from the workflow file

Contributes to https://github.com/rapidsai/shared-workflows/issues/337

* switches from input `run_script` to `script` in uses of the `custom-job` workflow

Contributes to https://github.com/rapidsai/build-planning/issues/179

* adds a call to `rapids-init-pip` near the beginning of all CI scripts that use `pip`
* removes redefinitions of `PIP_CONSTRAINT` in scripts, in favor of using the one set up by `rapids-pip-init`

Contributes to https://github.com/rapidsai/gha-tools/issues/145

* confirmed that `rapids-configure-conda-channels` is not used in any builds scripts using `rattler-build`
