### PR TITLE
WIP: begin fixing generators to prepare for networkx 3.5

### DIFF
--- a/nx_cugraph/generators/_utils.py
+++ b/nx_cugraph/generators/_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import operator as op
+from collections import Counter
 
 import cupy as cp
 import networkx as nx
@@ -48,18 +49,47 @@ def _complete_graph_indices(n):
     return (src_indices[mask], dst_indices[mask])
 
 
-def _common_small_graph(n, nodes, create_using, *, allow_directed=True):
+def _common_small_graph(
+    n, nodes, create_using, *, allow_directed=True, self_loops=None
+):
     """Create a "common graph" for small n.
 
     n == 0: empty graph
-    n == 1: empty graph
-    n == 2: complete graph
+    n == 1: empty graph (unless has self-loops)
+    n == 2: complete graph (may have self-loops)
     n > 2: undefined
     """
     graph_class, inplace = _create_using_class(create_using)
     if not allow_directed and graph_class.is_directed():
         raise nx.NetworkXError("Directed Graph not supported")
-    if n < 2:
+    if self_loops:
+        if n == 1:
+            G = graph_class.from_coo(
+                n,
+                cp.zeros(1, dtype=index_dtype),
+                cp.zeros(1, dtype=index_dtype),
+                id_to_key=nodes,
+            )
+        # n == 2
+        elif len(self_loops) == 2:
+            G = graph_class.from_coo(
+                n,
+                cp.ones(1, dtype=index_dtype),
+                cp.ones(1, dtype=index_dtype),
+                id_to_key=nodes,
+            )
+            1 / 0
+        else:
+            [self_loop] = self_loops
+            index = nodes.index(self_loop)
+            if index == 0:
+                src = cp.array([0, 0, 1], dtype=index_dtype)  # [[1, 1],
+                dst = cp.array([0, 1, 0], dtype=index_dtype)  #  [1, 0]]
+            else:
+                src = cp.array([0, 1, 1], dtype=index_dtype)  # [[0, 1],
+                dst = cp.array([1, 0, 1], dtype=index_dtype)  #  [1, 1]]
+            G = graph_class.from_coo(n, src, dst, id_to_key=nodes)
+    elif n < 2:
         G = graph_class.from_coo(
             n, cp.empty(0, index_dtype), cp.empty(0, index_dtype), id_to_key=nodes
         )
@@ -119,22 +149,45 @@ def _create_using_class(create_using, *, default=nx.Graph):
     return graph_class, inplace
 
 
-def _number_and_nodes(n_and_nodes):
+def _number_and_nodes(n_and_nodes, *, drop_duplicates=False, return_selfloops=False):
     n, nodes = n_and_nodes
     try:
         n = op.index(n)
     except TypeError:
         n = len(nodes)
-    if n < 0:
-        raise nx.NetworkXError(f"Negative number of nodes not valid: {n}")
-    if not isinstance(nodes, list):
-        nodes = list(nodes)
-    if not nodes:
+    else:
+        if n < 0:
+            raise nx.NetworkXError(f"Negative number of nodes not valid: {n}")
+    # `_nodes_or_number` from nx returns nodes of type:
+    #   - list: if generated from int as `list(range(n))`
+    #   - tuple: if user-provided as `tuple(n)`
+    if not nodes or isinstance(nodes, list):
+        if return_selfloops:
+            return (n, None, None)
         return (n, None)
+
+    if return_selfloops:
+        counter = Counter(nodes)
+        if len(counter) < n:
+            if drop_duplicates:
+                nodes = list(counter)
+                n = len(nodes)
+            self_loops = {k: v for k, v in counter.items() if v > 1}
+        else:
+            self_loops = None
+    elif drop_duplicates:
+        nodes = list(dict.fromkeys(nodes))  # Drop duplicates, keep order
+        n = len(nodes)
+    else:
+        nodes = list(nodes)
     if nodes[0] == 0 and nodes[n - 1] == n - 1:
         try:
             if nodes == list(range(n)):
+                if return_selfloops:
+                    return (n, None, self_loops)
                 return (n, None)
         except Exception:
             pass
+    if return_selfloops:
+        return (n, nodes, self_loops)
     return (n, nodes)

--- a/nx_cugraph/tests/test_generators.py
+++ b/nx_cugraph/tests/test_generators.py
@@ -79,6 +79,7 @@ def compare(name, create_using, *args, is_vanilla=False):
 
 
 N = list(range(-1, 5))
+N_AND_NODES = N + ["a", "aa", "aba", "bba", "abba", "abc", "abcb", [0, 1, 2]]
 CREATE_USING = [nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph]
 COMPLETE_CREATE_USING = [
     nx.Graph,
@@ -215,6 +216,17 @@ def test_generator_n(name, n, create_using):
 @pytest.mark.parametrize("n", [1, 4])
 @pytest.mark.parametrize("create_using", COMPLETE_CREATE_USING)
 def test_generator_n_complete(name, n, create_using):
+    print(name, n, create_using)
+    compare(name, create_using, n)
+
+
+GENERATORS_N_AND_STRINGS = list(GENERATORS_N)
+
+
+@pytest.mark.parametrize("name", GENERATORS_N_AND_STRINGS)
+@pytest.mark.parametrize("n", N_AND_NODES)
+@pytest.mark.parametrize("create_using", CREATE_USING)
+def test_generator_n_and_nodes(name, n, create_using):
     print(name, n, create_using)
     compare(name, create_using, n)
 

--- a/nx_cugraph/tests/testing_utils.py
+++ b/nx_cugraph/tests/testing_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -31,8 +31,14 @@ def assert_graphs_equal(Gnx, Gcg):
         assert sorted(G._node) == sorted(Gnx._node)
         for k in sorted(G._adj):
             print(k, sorted(G._adj[k]), sorted(Gnx._adj[k]))
-        print(nx.to_scipy_sparse_array(G).todense())
-        print(nx.to_scipy_sparse_array(Gnx).todense())
-        print(G.graph)
-        print(Gnx.graph)
+        if len(G) > 0:
+            print(nx.to_scipy_sparse_array(G).todense())
+        else:
+            print(G)
+        if len(Gnx) > 0:
+            print(nx.to_scipy_sparse_array(Gnx).todense())
+        else:
+            print(Gnx)
+        print(f"{G.graph=}")
+        print(f"{Gnx.graph=}")
     assert rv


### PR DESCRIPTION
Many tests will fail when nx-cugraph is run against NetworkX 3.5 (due to be released at any time). I don't know how many.

The reason for most of these failures comes from the changes in https://github.com/networkx/networkx/pull/7982, which paid off technical debt to unblock other nx PRs, and in the process enabled more thorough testing. This more thorough testing catches more behaviors that we don't yet implement.

Most (maybe all?) of the new failures are probably non-issues in practice and low priority. As such, this PR is a WIP and has been incrementally worked on in tiny spurts. It's the kind of work that can be done with quick context switches--say, when one is performing a task that regularly requires waiting for a few minutes.

When we begin to see test failures b/c we're testing against NetworkX 3.5, we'll need to choose how to proceed. Ideas:
- fix some or all of the failing tests (this PR)
- skip the failing tests (how many?)
- test against NetworkX 3.4.2 in CI until we can pass against 3.5

Regardless, we'll probably want to do a cursory scan of the failed tests to get an idea of the scale of the work.