### PR TITLE
stop uploading packages to downloads.rapids.ai

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -30,5 +30,3 @@ rattler-build build --recipe conda/recipes/nx-cugraph \
                     --test skip \
                     "${RATTLER_ARGS[@]}" \
                     "${RATTLER_CHANNELS[@]}"
-
-rapids-upload-conda-to-s3 python

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -3,13 +3,10 @@
 
 set -euo pipefail
 
-package_name=$1
-package_dir=$2
+package_dir=$1
 
 source rapids-date-string
 source rapids-init-pip
-
-RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 
 rapids-generate-version > ./VERSION
 
@@ -22,5 +19,3 @@ rapids-pip-retry wheel \
     --disable-pip-version-check \
     --extra-index-url https://pypi.nvidia.com \
     .
-
-RAPIDS_PY_WHEEL_NAME="${package_name}_${RAPIDS_PY_CUDA_SUFFIX}" RAPIDS_PY_WHEEL_PURE="1" rapids-upload-wheels-to-s3 python "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"

--- a/ci/build_wheel_nx-cugraph.sh
+++ b/ci/build_wheel_nx-cugraph.sh
@@ -5,5 +5,5 @@ set -euo pipefail
 
 source rapids-init-pip
 
-./ci/build_wheel.sh nx-cugraph .
+./ci/build_wheel.sh .
 ./ci/validate_wheel.sh "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/181

* removes all uploads of conda packages and wheels to `downloads.rapids.ai`

## Notes for Reviewers

### How I identified changes

Looked for uses of the relevant `gha-tools` tools, as well as documentation about `downloads.rapids.ai`, being on the NVIDIA VPN, using S3, etc. like this:

```shell
git grep -i -E 's3|upload|downloads\.rapids|vpn'
```

### How I tested this

See "How I tested this" on https://github.com/rapidsai/shared-workflows/pull/364