### PR TITLE
Use environment as default for RAPIDS_DATASET_ROOT_DIR, improve benchmark docs

### DIFF
--- a/benchmarks/pytest-based/README.md
+++ b/benchmarks/pytest-based/README.md
@@ -6,15 +6,21 @@ This directory contains a set of scripts designed to benchmark NetworkX with the
 
 Our current benchmarks provide the following datasets:
 
-| Dataset     | Nodes | Edges | Directed |
-| --------    | ------- | ------- | ------- |
-| netscience  | 1,461    | 5,484 | Yes |
-| email-Eu-core  | 1,005    | 25,571 | Yes |
-| cit-Patents  | 3,774,768    | 16,518,948 | Yes |
-| hollywood  | 1,139,905    | 57,515,616 | No |
-| soc-LiveJournal1  | 4,847,571    | 68,993,773 | Yes |
+| Dataset          | Nodes     | Edges      | Directed |
+| ---------------- | --------- | ---------- | -------- |
+| netscience       | 1,461     | 5,484      | Yes      |
+| email-Eu-core    | 1,005     | 25,571     | Yes      |
+| cit-Patents      | 3,774,768 | 16,518,948 | Yes      |
+| hollywood        | 1,139,905 | 57,515,616 | No       |
+| soc-LiveJournal1 | 4,847,571 | 68,993,773 | Yes      |
 
+### Requirements
 
+Install nx-cugraph and the benchmark dependencies:
+
+```
+conda create -n nx-cugraph-benchmark -c rapidsai -c conda-forge nx-cugraph pytest pytest-benchmark
+```
 
 ### Scripts
 

--- a/benchmarks/pytest-based/get_graph_bench_dataset.py
+++ b/benchmarks/pytest-based/get_graph_bench_dataset.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -13,7 +13,7 @@
 
 """
 Checks if a particular dataset has been downloaded inside the datasets dir
-(RAPIDS_DATAEST_ROOT_DIR). If not, the file will be downloaded using the
+(RAPIDS_DATASET_ROOT_DIR). If not, the file will be downloaded using the
 datasets API.
 
 Positional Arguments:

--- a/benchmarks/pytest-based/run-main-benchmarks.sh
+++ b/benchmarks/pytest-based/run-main-benchmarks.sh
@@ -14,7 +14,7 @@
 
 
 # location to store datasets used for benchmarking
-export RAPIDS_DATASET_ROOT_DIR=/datasets/cugraph
+export RAPIDS_DATASET_ROOT_DIR=${RAPIDS_DATASET_ROOT_DIR:-"/datasets/cugraph"}
 mkdir -p logs
 
 # list of algos, datasets, and back-ends to use in combinations


### PR DESCRIPTION
This makes it easier to run benchmarks, by respecting the default value of `${RAPIDS_DATASET_ROOT_DIR}` if defined in the user's environment.

I also made minor improvements to the benchmarking docs.