### PR TITLE
Updates can_run function signature for forceatlas2_layout

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
         types: [python]
         language: python
         pass_filenames: false
-        additional_dependencies: ["networkx>=3.4"]
+        additional_dependencies: ["networkx>=3.5"]
   - repo: local
     hooks:
       - id: nx-cugraph-readme-update
@@ -106,7 +106,7 @@ repos:
         types_or: [python, markdown]
         language: python
         pass_filenames: false
-        additional_dependencies: ["networkx>=3.4"]
+        additional_dependencies: ["networkx>=3.5"]
   - repo: local
     hooks:
       - id: disallow-improper-nxver-comparison

--- a/nx_cugraph/drawing/layout.py
+++ b/nx_cugraph/drawing/layout.py
@@ -193,6 +193,7 @@ def _(
     dim=2,
     store_pos_as=None,
     outbound_attraction_distribution=True,
+    dtype=None,
 ):
     if dim != 2:
         return f"dim={dim} not supported; only dim=2 is currently supported"


### PR DESCRIPTION
Updates `can_run` function signature for `forceatlas2_layout` to add missing `dtype` arg. This fixes a test failure in `test_match_signature_and_names` which now runs for `forceatlas2_layout` due to it being supported in NX 3.5.