### PR TITLE
Catch `CUDARuntimeError` in CuPy GPU check

### DIFF
--- a/benchmarks/pytest-based/bench_algos.py
+++ b/benchmarks/pytest-based/bench_algos.py
@@ -72,7 +72,7 @@ def setup_module(module):
     has_cuda_gpu = False
     try:
         has_cuda_gpu = cp.cuda.is_available()
-    except p.cuda.runtime.CUDARuntimeError:
+    except cp.cuda.runtime.CUDARuntimeError:
         # Treat errors as no GPU available.
         # xref: https://github.com/cupy/cupy/issues/9091
         pass

--- a/benchmarks/pytest-based/bench_algos.py
+++ b/benchmarks/pytest-based/bench_algos.py
@@ -74,6 +74,7 @@ def setup_module(module):
         has_cuda_gpu = cp.cuda.is_available()
     except p.cuda.runtime.CUDARuntimeError:
         # Treat errors as no GPU available.
+        # xref: https://github.com/cupy/cupy/issues/9091
         pass
 
     if has_cuda_gpu:

--- a/benchmarks/pytest-based/bench_algos.py
+++ b/benchmarks/pytest-based/bench_algos.py
@@ -69,7 +69,7 @@ def setup_module(module):
     Trivial conversion call to force various one-time CUDA initialization
     operations to happen outside of benchmarks (if GPU is available).
     """
-    if cp.cuda.is_available():
+    if cp.is_available():
         print("CUDA is available, running one-time code to force initialization.")
         G = nx.karate_club_graph()
         nxcg.from_networkx(G)

--- a/benchmarks/pytest-based/bench_algos.py
+++ b/benchmarks/pytest-based/bench_algos.py
@@ -69,7 +69,14 @@ def setup_module(module):
     Trivial conversion call to force various one-time CUDA initialization
     operations to happen outside of benchmarks (if GPU is available).
     """
-    if cp.is_available():
+    has_cuda_gpu = False
+    try:
+        has_cuda_gpu = cp.cuda.is_available()
+    except p.cuda.runtime.CUDARuntimeError:
+        # Treat errors as no GPU available.
+        pass
+
+    if has_cuda_gpu:
         print("CUDA is available, running one-time code to force initialization.")
         G = nx.karate_club_graph()
         nxcg.from_networkx(G)


### PR DESCRIPTION
Catch `CUDARuntimeError` in the benchmarks when checking for a GPU and treat it as no GPU is available.