### PR TITLE
Update rapids-build-backend to 0.4.1

### DIFF
--- a/conda/recipes/nx-cugraph/recipe.yaml
+++ b/conda/recipes/nx-cugraph/recipe.yaml
@@ -27,7 +27,7 @@ requirements:
   host:
     - pip
     - python =${{ py_version }}
-    - rapids-build-backend >=0.3.0,<0.4.0.dev0
+    - rapids-build-backend >=0.4.0,<0.5.0.dev0
     - setuptools
   run:
     - cupy >=12.0.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -129,7 +129,7 @@ dependencies:
     common:
       - output_types: [conda, pyproject, requirements]
         packages:
-          - rapids-build-backend>=0.3.1,<0.4.0.dev0
+          - rapids-build-backend>=0.4.0,<0.5.0.dev0
   python_build_wheel:
     common:
       - output_types: [conda, pyproject, requirements]


### PR DESCRIPTION
This PR updates rapids-build-backend to 0.4.1, and errors out if any MANIFEST.in file is present.
