### PR TITLE
Update rapids-dependency-file-generator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@ repos:
     rev: v1.20.0
     hooks:
         - id: rapids-dependency-file-generator
-          args: ["--clean"]
+          args: ["--clean", "--warn-all", "--strict"]
   - repo: local
     hooks:
       - id: nx-cugraph-meta-data-update

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,7 +83,7 @@ repos:
         # Don't have strict linting for miscellaneous code
         args: [--extend-exclude, "benchmarks/,ci/,notebooks/"]
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.19.0
+    rev: v1.20.0
     hooks:
         - id: rapids-dependency-file-generator
           args: ["--clean"]


### PR DESCRIPTION
This PR updates the rapids-dependency-file-generator hook to get https://github.com/rapidsai/dependency-file-generator/pull/163.
