### PR TITLE
Use current system architecture in conda environment creation command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ cd nx-cugraph
 
 ```bash
 # for CUDA 13 environments
-conda env create --name nxcg-dev --file conda/environments/all_cuda-130_arch-$(arch).yaml
+conda env create --name nxcg-dev --file conda/environments/all_cuda-130_arch-$(uname -m).yaml
 
 # activate the environment
 conda activate nxcg-dev


### PR DESCRIPTION
This fixes a conda environment creation command to support both `x86_64` and `aarch64` systems.