### PR TITLE
fix(wheels): override wheel artifact name in input to publish job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,3 +74,4 @@ jobs:
       date: ${{ inputs.date }}
       package-name: nx-cugraph
       package-type: python
+      publish-wheel-search-key: "nx-cugraph_wheel"


### PR DESCRIPTION
Followup to #198, fixes the wheel publishing workflow
