### PR TITLE
Perf: use GPU-only searchsorted instead of numpy.repeat

### DIFF
--- a/benchmarks/pytest-based/bench_algos.py
+++ b/benchmarks/pytest-based/bench_algos.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import random
@@ -253,6 +253,22 @@ def possible_to_fail(exception, function):
 # Benchmarks
 def bench_from_networkx(benchmark, graph_obj):
     benchmark(nxcg.from_networkx, graph_obj)
+
+
+def bench_from_csr(benchmark, graph_obj):
+    """Benchmark building a CudaGraph from GPU-resident CSR arrays.
+
+    This exercises the `from_csr` code path that expands `indptr` to COO row
+    indices. Inputs are pre-built on the GPU so the benchmark isolates the
+    expansion step.
+    """
+    A = nx.to_scipy_sparse_array(graph_obj, format="csr")
+    indptr = cp.asarray(A.indptr, dtype=np.int32)
+    dst_indices = cp.asarray(A.indices, dtype=np.int32)
+    cp.cuda.Stream.null.synchronize()
+
+    graph_cls = nxcg.DiGraph if graph_obj.is_directed() else nxcg.Graph
+    benchmark(graph_cls.from_csr, indptr, dst_indices)
 
 
 # normalized_param_values = [True, False]

--- a/nx_cugraph/classes/graph.py
+++ b/nx_cugraph/classes/graph.py
@@ -408,9 +408,13 @@ class Graph(nx.Graph):
         **attr,
     ) -> Graph | CudaGraph:
         N = indptr.size - 1
-        src_indices = cp.array(
-            # cp.repeat is slow to use here, so use numpy instead
-            np.repeat(np.arange(N, dtype=index_dtype), cp.diff(indptr).get())
+        # Equivalent to: cp.repeat(cp.arange(N, dtype=index_dtype), cp.diff(indptr))
+        # but cp.repeat doesn't support ndarray repeats (see cupy/cupy#9828).
+        src_indices = (
+            cp.searchsorted(
+                indptr, cp.arange(dst_indices.size, dtype=index_dtype), side="right"
+            ).astype(index_dtype)
+            - 1
         )
         return cls.from_coo(
             N,
@@ -442,9 +446,13 @@ class Graph(nx.Graph):
         **attr,
     ) -> Graph | CudaGraph:
         N = indptr.size - 1
-        dst_indices = cp.array(
-            # cp.repeat is slow to use here, so use numpy instead
-            np.repeat(np.arange(N, dtype=index_dtype), cp.diff(indptr).get())
+        # Equivalent to: cp.repeat(cp.arange(N, dtype=index_dtype), cp.diff(indptr))
+        # but cp.repeat doesn't support ndarray repeats (see cupy/cupy#9828).
+        dst_indices = (
+            cp.searchsorted(
+                indptr, cp.arange(src_indices.size, dtype=index_dtype), side="right"
+            ).astype(index_dtype)
+            - 1
         )
         return cls.from_coo(
             N,
@@ -477,10 +485,15 @@ class Graph(nx.Graph):
         use_compat_graph: bool | None = None,
         **attr,
     ) -> Graph | CudaGraph:
-        src_indices = cp.array(
-            # cp.repeat is slow to use here, so use numpy instead
-            np.repeat(compressed_srcs.get(), cp.diff(indptr).get())
+        # Equivalent to: cp.repeat(compressed_srcs, cp.diff(indptr))
+        # but cp.repeat doesn't support ndarray repeats (see cupy/cupy#9828).
+        compressed_idx = (
+            cp.searchsorted(
+                indptr, cp.arange(dst_indices.size, dtype=index_dtype), side="right"
+            )
+            - 1
         )
+        src_indices = compressed_srcs[compressed_idx]
         return cls.from_coo(
             N,
             src_indices,
@@ -512,10 +525,15 @@ class Graph(nx.Graph):
         use_compat_graph: bool | None = None,
         **attr,
     ) -> Graph | CudaGraph:
-        dst_indices = cp.array(
-            # cp.repeat is slow to use here, so use numpy instead
-            np.repeat(compressed_dsts.get(), cp.diff(indptr).get())
+        # Equivalent to: cp.repeat(compressed_dsts, cp.diff(indptr))
+        # but cp.repeat doesn't support ndarray repeats (see cupy/cupy#9828).
+        compressed_idx = (
+            cp.searchsorted(
+                indptr, cp.arange(src_indices.size, dtype=index_dtype), side="right"
+            )
+            - 1
         )
+        dst_indices = compressed_dsts[compressed_idx]
         return cls.from_coo(
             N,
             src_indices,

--- a/nx_cugraph/classes/multigraph.py
+++ b/nx_cugraph/classes/multigraph.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, ClassVar
 
 import cupy as cp
 import networkx as nx
-import numpy as np
 
 import nx_cugraph as nxcg
 
@@ -132,9 +131,13 @@ class MultiGraph(nx.MultiGraph, Graph):
         **attr,
     ) -> MultiGraph | CudaMultiGraph:
         N = indptr.size - 1
-        src_indices = cp.array(
-            # cp.repeat is slow to use here, so use numpy instead
-            np.repeat(np.arange(N, dtype=index_dtype), cp.diff(indptr).get())
+        # Equivalent to: cp.repeat(cp.arange(N, dtype=index_dtype), cp.diff(indptr))
+        # but cp.repeat doesn't support ndarray repeats (see cupy/cupy#9828).
+        src_indices = (
+            cp.searchsorted(
+                indptr, cp.arange(dst_indices.size, dtype=index_dtype), side="right"
+            ).astype(index_dtype)
+            - 1
         )
         return cls.from_coo(
             N,
@@ -170,9 +173,13 @@ class MultiGraph(nx.MultiGraph, Graph):
         **attr,
     ) -> MultiGraph | CudaMultiGraph:
         N = indptr.size - 1
-        dst_indices = cp.array(
-            # cp.repeat is slow to use here, so use numpy instead
-            np.repeat(np.arange(N, dtype=index_dtype), cp.diff(indptr).get())
+        # Equivalent to: cp.repeat(cp.arange(N, dtype=index_dtype), cp.diff(indptr))
+        # but cp.repeat doesn't support ndarray repeats (see cupy/cupy#9828).
+        dst_indices = (
+            cp.searchsorted(
+                indptr, cp.arange(src_indices.size, dtype=index_dtype), side="right"
+            ).astype(index_dtype)
+            - 1
         )
         return cls.from_coo(
             N,
@@ -209,10 +216,15 @@ class MultiGraph(nx.MultiGraph, Graph):
         use_compat_graph: bool | None = None,
         **attr,
     ) -> MultiGraph | CudaMultiGraph:
-        src_indices = cp.array(
-            # cp.repeat is slow to use here, so use numpy instead
-            np.repeat(compressed_srcs.get(), cp.diff(indptr).get())
+        # Equivalent to: cp.repeat(compressed_srcs, cp.diff(indptr))
+        # but cp.repeat doesn't support ndarray repeats (see cupy/cupy#9828).
+        compressed_idx = (
+            cp.searchsorted(
+                indptr, cp.arange(dst_indices.size, dtype=index_dtype), side="right"
+            )
+            - 1
         )
+        src_indices = compressed_srcs[compressed_idx]
         return cls.from_coo(
             N,
             src_indices,
@@ -248,10 +260,15 @@ class MultiGraph(nx.MultiGraph, Graph):
         use_compat_graph: bool | None = None,
         **attr,
     ) -> MultiGraph | CudaGraph:
-        dst_indices = cp.array(
-            # cp.repeat is slow to use here, so use numpy instead
-            np.repeat(compressed_dsts.get(), cp.diff(indptr).get())
+        # Equivalent to: cp.repeat(compressed_dsts, cp.diff(indptr))
+        # but cp.repeat doesn't support ndarray repeats (see cupy/cupy#9828).
+        compressed_idx = (
+            cp.searchsorted(
+                indptr, cp.arange(src_indices.size, dtype=index_dtype), side="right"
+            )
+            - 1
         )
+        dst_indices = compressed_dsts[compressed_idx]
         return cls.from_coo(
             N,
             src_indices,

--- a/nx_cugraph/convert.py
+++ b/nx_cugraph/convert.py
@@ -353,7 +353,8 @@ def from_networkx(
         num_multiedges, is_dicts = _iterate_values(
             None, adj, is_dicts, lambda it: np.fromiter(map(len, it), index_dtype)
         )
-        # cp.repeat is slow to use here, so use numpy instead
+        # Data originates from CPU (Python iteration), so numpy repeat
+        # is appropriate here.
         dst_indices = cp.array(np.repeat(dst_indices, num_multiedges))
         # Determine edge keys and edge ids for multigraphs
         if is_dicts:
@@ -439,7 +440,8 @@ def from_networkx(
                     edge_values[edge_attr] = cp.fromiter(iter_values, dtype)
             # if vals.ndim > 1: ...
 
-    # cp.repeat is slow to use here, so use numpy instead
+    # Data originates from CPU (Python iteration), so numpy repeat
+    # is appropriate here.
     src_indices = np.repeat(
         np.arange(N, dtype=index_dtype),
         np.fromiter(map(len, adj.values()), index_dtype),
@@ -794,8 +796,9 @@ def from_dict_of_lists(d, create_using=None):
 
     graph_class, inplace = _create_using_class(create_using)
     key_to_id = defaultdict(itertools.count().__next__)
+    # Data originates from CPU (Python iterators), so numpy repeat is
+    # appropriate here.
     src_indices = cp.array(
-        # cp.repeat is slow to use here, so use numpy instead
         np.repeat(
             np.fromiter(map(key_to_id.__getitem__, d), index_dtype),
             np.fromiter(map(len, d.values()), index_dtype),


### PR DESCRIPTION
The GPU-only searchsorted for doing indptr-to-COO expansion (which eliminates D2H transfers) is faster than numpy.repeat.

`cupy.repeat` does not yet support ndarray as `repeats` argument, so searchsorted is the appropriate recipe to do instead for most data. For very large data, a "cumsum+scatter" approach may be faster. `cp.repeat` is being updated in https://github.com/cupy/cupy/pull/9828

Example speed improvement:
- from_csr (1M nodes, 20M edges): 2.4ms vs 72ms (30x faster)

This PR was motivated by work I am doing in https://github.com/cupy/cupy/pull/9825