### PR TITLE
Temporarily disables pre-CUDA 12.9 test runs due to libcugraph limitation

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -142,6 +142,9 @@ jobs:
       build_type: pull-request
       run_codecov: false
       script: ci/test_python.sh
+      # TODO(#5498): Drop this filter once libcugraph no longer requires a CUDA >= 12.8
+      # cudart at runtime (ideally by statically linking libcudart again).
+      matrix_filter: map(select(.CUDA_VER | split(".") | map(tonumber) >= [12, 9]))
   wheel-build-nx-cugraph:
     needs: [checks]
     secrets: inherit
@@ -161,4 +164,7 @@ jobs:
       build_type: pull-request
       script: ci/test_wheel_nx-cugraph.sh
       # This selects "ARCH=amd64 + the latest supported Python, 1 job per major CUDA version".
-      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+      # TODO(#5498): Drop the CUDA version filter once libcugraph no longer requires a CUDA >= 12.8
+      # cudart at runtime (ideally by statically linking libcudart again).
+      # matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+      matrix_filter: map(select(.ARCH == "amd64" and (.CUDA_VER | split(".") | map(tonumber) >= [12, 9]))) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,10 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       # This selects "ARCH=amd64 + the latest supported Python, 1 job per major CUDA version".
-      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+      # TODO(#5498): Drop the CUDA version filter once libcugraph no longer requires a CUDA >= 12.8
+      # cudart at runtime (ideally by statically linking libcudart again).
+      # matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+      matrix_filter: map(select(.ARCH == "amd64" and (.CUDA_VER | split(".") | map(tonumber) >= [12, 9]))) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
       run_codecov: false
       script: ci/test_python.sh
   wheel-tests-nx-cugraph:
@@ -45,4 +48,7 @@ jobs:
       sha: ${{ inputs.sha }}
       script: ci/test_wheel_nx-cugraph.sh
       # This selects "ARCH=amd64 + the latest supported Python, 1 job per major CUDA version".
-      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+      # TODO(#5498): Drop the CUDA version filter once libcugraph no longer requires a CUDA >= 12.8
+      # cudart at runtime (ideally by statically linking libcudart again).
+      # matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+      matrix_filter: map(select(.ARCH == "amd64" and (.CUDA_VER | split(".") | map(tonumber) >= [12, 9]))) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))

--- a/ci/test_wheel_nx-cugraph.sh
+++ b/ci/test_wheel_nx-cugraph.sh
@@ -38,8 +38,6 @@ else
     # FIXME: Adding PY_IGNORE_IMPORTMISMATCH=1 to workaround conftest.py import
     # mismatch error seen by nx-cugraph after using pytest 8 and
     # --import-mode=append.
-    # FIXME: Temporarily skipping test_k_truss[les_miserables_graph] due to upstream problem in cugraph on RTX 6000
-    # xref: https://github.com/rapidsai/cugraph/pull/5487
     RAPIDS_DATASET_ROOT_DIR=$(pwd)/datasets \
     PY_IGNORE_IMPORTMISMATCH=1 \
     NX_CUGRAPH_USE_COMPAT_GRAPHS=False \
@@ -47,6 +45,5 @@ else
        -v \
        --import-mode=append \
        --benchmark-disable \
-       -k "not test_k_truss[les_miserables_graph]" \
        ./"${python_package_name}"/tests
 fi

--- a/ci/test_wheel_nx-cugraph.sh
+++ b/ci/test_wheel_nx-cugraph.sh
@@ -38,6 +38,8 @@ else
     # FIXME: Adding PY_IGNORE_IMPORTMISMATCH=1 to workaround conftest.py import
     # mismatch error seen by nx-cugraph after using pytest 8 and
     # --import-mode=append.
+    # FIXME: Temporarily skipping test_k_truss[les_miserables_graph] due to upstream problem in cugraph on RTX 6000
+    # xref: https://github.com/rapidsai/cugraph/pull/5487
     RAPIDS_DATASET_ROOT_DIR=$(pwd)/datasets \
     PY_IGNORE_IMPORTMISMATCH=1 \
     NX_CUGRAPH_USE_COMPAT_GRAPHS=False \
@@ -45,5 +47,6 @@ else
        -v \
        --import-mode=append \
        --benchmark-disable \
+       -k "not test_k_truss[les_miserables_graph]" \
        ./"${python_package_name}"/tests
 fi


### PR DESCRIPTION
Temporarily disables pre-CUDA 12.9 test runs due to libcugraph limitation

xref:
https://github.com/rapidsai/cugraph/pull/5483