### PR TITLE
Guard CuPy CTK extra for wheel metadata

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -252,23 +252,23 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=14.0.1,!=14.1.0
+              - &cupy_cu12 cupy-cuda12x>=14.0.1,!=14.1.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cupy-cuda13x>=14.0.1,!=14.1.0
+              - &cupy_cu13 cupy-cuda13x>=14.0.1,!=14.1.0
       - output_types: pyproject
         matrices:
           - matrix:
               cuda: "12.*"
               use_cuda_wheels: "false"
             packages:
-              - cupy-cuda12x>=14.0.1,!=14.1.0
+              - *cupy_cu12
           - matrix:
               cuda: "13.*"
               use_cuda_wheels: "false"
             packages:
-              - cupy-cuda13x>=14.0.1,!=14.1.0
+              - *cupy_cu13
           - matrix:
               cuda: "12.*"
             packages:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -247,8 +247,28 @@ dependencies:
     #       other packages with -cu{nn}x suffixes in this file.
     #       All RAPIDS wheel builds (including in devcontainers) expect cupy to be suffixed.
     specific:
-      - output_types: [pyproject, requirements]
+      - output_types: requirements
         matrices:
+          - matrix:
+              cuda: "12.*"
+            packages:
+              - cupy-cuda12x>=14.0.1,!=14.1.0
+          # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
+          - matrix:
+            packages:
+              - cupy-cuda13x>=14.0.1,!=14.1.0
+      - output_types: pyproject
+        matrices:
+          - matrix:
+              cuda: "12.*"
+              use_cuda_wheels: "false"
+            packages:
+              - cupy-cuda12x>=14.0.1,!=14.1.0
+          - matrix:
+              cuda: "13.*"
+              use_cuda_wheels: "false"
+            packages:
+              - cupy-cuda13x>=14.0.1,!=14.1.0
           - matrix:
               cuda: "12.*"
             packages:


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/279

This keeps `cupy-cuda12x[ctk]` and `cupy-cuda13x[ctk]` in wheel metadata when CUDA wheels are used, while generating bare `cupy-cuda12x` and `cupy-cuda13x` metadata when `use_cuda_wheels=false`.