### PR TITLE
Update notebook code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,7 @@ python/            @rapidsai/nx-cugraph-python-codeowners
 pyproject.toml     @rapidsai/packaging-codeowners
 
 # notebooks code owners
-*.ipynb @rapidsai/cugraph-notebook-codeowners
+*.ipynb @rapidsai/nx-cugraph-python-codeowners
 
 # Ops code owners
 /SECURITY.md             @rapidsai/ops-codeowners


### PR DESCRIPTION
## Summary

- assign all `*.ipynb` files to `@rapidsai/nx-cugraph-python-codeowners`
- replace the live reference to the cuGraph notebook code-owner team in `.github/CODEOWNERS`

## Impact

nx-cugraph Python code owners will now be requested for every notebook change in this repository.

## Validation

- `git diff --check`
- verified the live CODEOWNERS file no longer references `cugraph-notebook-codeowners`
- confirmed the rule covers all six notebooks currently in the repository
