### PR TITLE
Add release catalog canary

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ permissions: {}
 jobs:
   conda-python-build:
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@codex/release-build-output-manifests
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -41,6 +41,8 @@ jobs:
       script: ci/build_python.sh
       sha: ${{ inputs.sha }}
       pure-conda: true
+      release-build-output: true
+      release-unit: conda:nx-cugraph
     permissions:
       actions: read
       contents: read
@@ -66,7 +68,7 @@ jobs:
       pull-requests: read
   wheel-build-nx-cugraph:
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
@@ -76,6 +78,8 @@ jobs:
       package-name: nx-cugraph
       package-type: python
       pure-wheel: true
+      release-build-output: true
+      release-unit: wheel:nx-cugraph
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,8 +41,6 @@ jobs:
       script: ci/build_python.sh
       sha: ${{ inputs.sha }}
       pure-conda: true
-      release-build-output: true
-      release-unit: conda:nx-cugraph
     permissions:
       actions: read
       contents: read
@@ -78,8 +76,6 @@ jobs:
       package-name: nx-cugraph
       package-type: python
       pure-wheel: true
-      release-build-output: true
-      release-unit: wheel:nx-cugraph
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -144,11 +144,13 @@ jobs:
   conda-python-build:
     needs: [checks]
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@codex/release-build-output-manifests
     with:
       build_type: pull-request
       script: ci/build_python.sh
       pure-conda: true
+      release-build-output: true
+      release-unit: conda:nx-cugraph
     permissions:
       actions: read
       contents: read
@@ -173,13 +175,15 @@ jobs:
   wheel-build-nx-cugraph:
     needs: [checks]
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@codex/release-build-output-manifests
     with:
       build_type: pull-request
       script: ci/build_wheel_nx-cugraph.sh
       package-name: nx-cugraph
       package-type: python
       pure-wheel: true
+      release-build-output: true
+      release-unit: wheel:nx-cugraph
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -149,8 +149,6 @@ jobs:
       build_type: pull-request
       script: ci/build_python.sh
       pure-conda: true
-      release-build-output: true
-      release-unit: conda:nx-cugraph
     permissions:
       actions: read
       contents: read
@@ -182,8 +180,6 @@ jobs:
       package-name: nx-cugraph
       package-type: python
       pure-wheel: true
-      release-build-output: true
-      release-unit: wheel:nx-cugraph
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
**Posted by Codex (GPT-5) on behalf of [@msarahan](https://github.com/msarahan). This pull request description is LLM-generated; readers should treat its content accordingly.**

## Summary

- point the Conda and wheel producer jobs at the development shared-workflows branch;
- exercise companion generation from both producer matrices; and
- validate repository-level catalog keys for the Conda and wheel publishable artifact sets.

This was a historical branch canary for the predecessor interface. The current contract uploads `release-catalog-<source-artifact-name>` companions containing one enveloped `release-catalog-entries.json` and evidence. These job-level entries are aggregated by the release platform into the release catalog.

The literal branch name `codex/release-build-output-manifests` and historical run artifact names retain the predecessor vocabulary because they are immutable Git and Actions identifiers.

## Evidence semantics

This producer does not supply a dependency SBOM. Its companions contain `generated-identity` SPDX envelopes, which identify package artifacts and checksums but must not be reported as dependency coverage.

Tracks [`rapidsai/build-infra#381`](https://github.com/rapidsai/build-infra/issues/381) and the current integration in [`rapidsai/shared-workflows#609`](https://github.com/rapidsai/shared-workflows/pull/609).

## Validation

- `pre-commit run --all-files`
- Black rerun through pre-commit under Python 3.11 because the machine's Python 3.12.5 is explicitly rejected by Black
- `git diff --check`
