### PR TITLE
ensure nightly builds always produce new packages, expand 'changed-files' lists

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,8 @@ concurrency:
   cancel-in-progress: true
 permissions: {}
 jobs:
+  build-details:
+    uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   conda-python-build:
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,10 +34,12 @@ jobs:
   build-details:
     uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   conda-python-build:
+    needs: [build-details]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       script: ci/build_python.sh
@@ -67,10 +69,12 @@ jobs:
       packages: read
       pull-requests: read
   wheel-build-nx-cugraph:
+    needs: [build-details]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       branch: ${{ inputs.branch }}
       sha: ${{ inputs.sha }}
       date: ${{ inputs.date }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,6 +10,7 @@ permissions: {}
 jobs:
   pr-builder:
     needs:
+      - build-details
       - check-nightly-ci
       - changed-files
       - checks
@@ -49,12 +50,19 @@ jobs:
         test_notebooks:
           - '**'
           - '!.devcontainer/**'
+          - '!.flake8'
+          - '!.github/CODEOWNERS'
           - '!.github/ISSUE_TEMPLATE/**'
           - '!.github/copy-pr-bot.yaml'
           - '!.github/labeler.yml'
           - '!.github/ops-bot.yaml'
           - '!.github/release.yml'
-          - '!.flake8'
+          - '!.github/workflows/add-to-project.yaml'
+          - '!.github/workflows/build.yaml'
+          - '!.github/workflows/labeler.yaml'
+          - '!.github/workflows/new-issues-to-triage-projects.yaml'
+          - '!.github/workflows/test.yaml'
+          - '!.github/zizmor.yml'
           - '!.pre-commit-config.yaml'
           - '!.shellcheckrc'
           - '!.yamllint.yaml'
@@ -69,11 +77,18 @@ jobs:
           - '**'
           - '!.devcontainer/**'
           - '!.flake8'
+          - '!.github/CODEOWNERS'
           - '!.github/ISSUE_TEMPLATE/**'
           - '!.github/copy-pr-bot.yaml'
           - '!.github/labeler.yml'
           - '!.github/ops-bot.yaml'
           - '!.github/release.yml'
+          - '!.github/workflows/add-to-project.yaml'
+          - '!.github/workflows/build.yaml'
+          - '!.github/workflows/labeler.yaml'
+          - '!.github/workflows/new-issues-to-triage-projects.yaml'
+          - '!.github/workflows/test.yaml'
+          - '!.github/zizmor.yml'
           - '!.pre-commit-config.yaml'
           - '!.shellcheckrc'
           - '!.yamllint.yaml'
@@ -91,11 +106,18 @@ jobs:
           - '**'
           - '!.devcontainer/**'
           - '!.flake8'
+          - '!.github/CODEOWNERS'
           - '!.github/ISSUE_TEMPLATE/**'
           - '!.github/copy-pr-bot.yaml'
           - '!.github/labeler.yml'
           - '!.github/ops-bot.yaml'
           - '!.github/release.yml'
+          - '!.github/workflows/add-to-project.yaml'
+          - '!.github/workflows/build.yaml'
+          - '!.github/workflows/labeler.yaml'
+          - '!.github/workflows/new-issues-to-triage-projects.yaml'
+          - '!.github/workflows/test.yaml'
+          - '!.github/zizmor.yml'
           - '!.pre-commit-config.yaml'
           - '!.shellcheckrc'
           - '!.yamllint.yaml'
@@ -144,11 +166,12 @@ jobs:
     permissions:
       contents: read
   conda-python-build:
-    needs: [checks]
+    needs: [build-details, checks]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: pull-request
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       script: ci/build_python.sh
       pure-conda: true
     permissions:
@@ -173,11 +196,12 @@ jobs:
       packages: read
       pull-requests: read
   wheel-build-nx-cugraph:
-    needs: [checks]
+    needs: [build-details, checks]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
     with:
       build_type: pull-request
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       script: ci/build_wheel_nx-cugraph.sh
       package-name: nx-cugraph
       package-type: python

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,6 +24,8 @@ jobs:
       needs: ${{ toJSON(needs) }}
     permissions:
       contents: read
+  build-details:
+    uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   check-nightly-ci:
     runs-on: ubuntu-latest
     permissions:

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
 
-source rapids-date-string
+source rapids-datetime-string
 
 rapids-print-env
 

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -6,10 +6,11 @@ set -euo pipefail
 
 package_dir=$1
 
-source rapids-date-string
+source rapids-datetime-string
 source rapids-init-pip
 
-rapids-generate-version > ./VERSION
+RAPIDS_VERSION_SUFFIX=".post${RAPIDS_DATETIME_STRING}" \
+  rapids-generate-version > ./VERSION
 
 cd "${package_dir}"
 

--- a/conda/recipes/nx-cugraph/recipe.yaml
+++ b/conda/recipes/nx-cugraph/recipe.yaml
@@ -5,7 +5,7 @@ schema_version: 1
 context:
   version: ${{ env.get("RAPIDS_PACKAGE_VERSION") }}
   minor_version: ${{ (version | split("."))[:2] | join(".") }}
-  date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
+  datetime_string: '${{ env.get("RAPIDS_DATETIME_STRING") }}'
   py_version: ${{ env.get("RAPIDS_PY_VERSION") }}
   head_rev: '${{ git.head_rev(".")[:8] }}'
 
@@ -18,7 +18,7 @@ source:
 
 build:
   noarch: python
-  string: py_${{ date_string }}_${{ head_rev }}
+  string: py_${{ datetime_string }}_${{ head_rev }}
   script:
     content: |
       ./build.sh nx-cugraph


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/218

* uses the new patterns for versioning nightly packages (see https://github.com/rapidsai/shared-workflows/pull/603), to ensure they're always uploaded on new builds. 

For wheels:

```text
# before
26.10.0a55 

# after
26.10.0a55.post260803200854
```

And for conda:

```text
# before
26.10.0a55[build=cuda12_260803_9da146ef]

# after
26.10.0a55[build=cuda12_260803200854_9da146ef]
```

Other changes:

* updates `changed-files` lists to avoid triggering test jobs in PR CI when only `.github/workflows/{build,test}.yaml` are changed

## Notes for Reviewers

### How I tested this

See https://github.com/rapidsai/cugraph-gnn/pull/508
