### PR TITLE
Fix NetworkX 3.5+ benchmark assert and eigenvector max_iter

### DIFF
--- a/benchmarks/pytest-based/bench_algos.py
+++ b/benchmarks/pytest-based/bench_algos.py
@@ -12,6 +12,7 @@ import pytest
 from cugraph import datasets
 
 import nx_cugraph as nxcg
+from nx_cugraph import _nxver
 
 ################################################################################
 # Fixtures and params
@@ -561,8 +562,12 @@ def bench_single_target_shortest_path_length(benchmark, graph_obj, backend_wrapp
         iterations=iterations,
         warmup_rounds=warmup_rounds,
     )
-    # NetworkX 3.5+ returns a dict (previously an iterator); keep assert in sync.
-    assert type(result) is dict
+    # NetworkX 3.5+ returns a dict; older versions return an iterator that
+    # force_unlazy_eval materializes to a list.
+    if _nxver >= (3, 5):
+        assert type(result) is dict
+    else:
+        assert type(result) is list
 
 
 def bench_ancestors(benchmark, graph_obj, backend_wrapper):

--- a/benchmarks/pytest-based/bench_algos.py
+++ b/benchmarks/pytest-based/bench_algos.py
@@ -561,11 +561,7 @@ def bench_single_target_shortest_path_length(benchmark, graph_obj, backend_wrapp
         iterations=iterations,
         warmup_rounds=warmup_rounds,
     )
-    # force_unlazy_eval=True forces iterators and other containers to generate
-    # a complete set of results (in order to include any deferred compute or
-    # conversion in the benchmark), but is not needed for this algo in NX 3.3+
-    # since it returns a dict instead of an iterator. Forcing eval does not
-    # change the benchmark timing.
+    # NetworkX 3.5+ returns a dict (previously an iterator); keep assert in sync.
     assert type(result) is dict
 
 

--- a/benchmarks/pytest-based/bench_algos.py
+++ b/benchmarks/pytest-based/bench_algos.py
@@ -563,7 +563,7 @@ def bench_single_target_shortest_path_length(benchmark, graph_obj, backend_wrapp
     # conversion in the benchmark), but is not needed for this algo in NX 3.3+
     # since it returns a dict instead of an iterator. Forcing eval does not
     # change the benchmark timing.
-    assert type(result) is list
+    assert type(result) is dict
 
 
 def bench_ancestors(benchmark, graph_obj, backend_wrapper):

--- a/benchmarks/pytest-based/bench_algos.py
+++ b/benchmarks/pytest-based/bench_algos.py
@@ -381,6 +381,9 @@ def bench_eigenvector_centrality(benchmark, graph_obj, backend_wrapper):
     result = benchmark.pedantic(
         target=backend_wrapper(nx.eigenvector_centrality),
         args=(G,),
+        # NetworkX/nx-cugraph default is max_iter=100, but NetworkX now fails to
+        # converge on amazon0302 at that limit; 150 works for both backends.
+        kwargs=dict(max_iter=150),
         rounds=rounds,
         iterations=iterations,
         warmup_rounds=warmup_rounds,

--- a/benchmarks/pytest-based/bench_algos.py
+++ b/benchmarks/pytest-based/bench_algos.py
@@ -381,8 +381,8 @@ def bench_eigenvector_centrality(benchmark, graph_obj, backend_wrapper):
     result = benchmark.pedantic(
         target=backend_wrapper(nx.eigenvector_centrality),
         args=(G,),
-        # NetworkX/nx-cugraph default is max_iter=100, but NetworkX now fails to
-        # converge on amazon0302 at that limit; 150 works for both backends.
+        # On amazon0302, max_iter=100 did not converge for NetworkX or nx-cugraph;
+        # both converged with 150 in testing.
         kwargs=dict(max_iter=150),
         rounds=rounds,
         iterations=iterations,


### PR DESCRIPTION
## Summary

While running the nx-cugraph algo-table NetworkX benchmarks, we hit two fixable failures and one expected OOM on large graphs (most visibly on amazon0302), all in `bench_algos.py`.

## Failures

- **`bench_single_target_shortest_path_length`** asserted that the result was a `list`, but the benchmark failed because NetworkX 3.5+ now returns a `dict` keyed by node. In older versions the function returned an iterator that the benchmark materialized into a list, so the assert was simply stale — the algorithm itself worked correctly.
- **`bench_eigenvector_centrality`** raised `PowerIterationFailedConvergence` because the default `max_iter=100` is not enough for amazon0302. Both the NetworkX and cugraph backends fail at 100 and converge at 150, and their scores agree within a margin of noise.
- **`bench_forceatlas2` / `bench_to_numpy_array`** OOMed on amazon0302. NetworkX ForceAtlas2 first builds a dense `n×n` adjacency matrix via `to_numpy_array`, and with ~262k nodes that requires ~512 GiB of RAM, so allocation fails before layout even starts. This is a fundamental cost of the dense CPU path on that graph size, not a bad assert we can patch. It succeeds on smaller datasets like netscience (~1.5k nodes). When this occurs on large graphs, the right response is to skip those benches rather than try to “fix” them.

## Fixes

- Updated the assert to expect a `dict`, along with a comment noting the NetworkX 3.5+ return-type change.
- Set `max_iter=150` for `eigenvector_centrality` so the power iteration can converge on amazon0302 for both backends.
- Left the FA2 / `to_numpy_array` OOM unresolved in code; recommend skipping those benchmarks on large datasets where a dense adjacency matrix cannot fit in memory.